### PR TITLE
Add multi-axis compat targets (Python version, free-threaded, OS, arch)

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -75,7 +75,7 @@ The library is particularly useful for projects that need to support multiple Py
 
 ```python
 from feu import is_package_available, install_package_closest_version
-from feu.compat import find_closest_version
+from feu.compat import Target, find_closest_version
 
 # Check if a package is available
 if is_package_available("numpy"):
@@ -83,7 +83,7 @@ if is_package_available("numpy"):
 
 # Find the closest valid version for your Python version
 version = find_closest_version(
-    pkg_name="numpy", pkg_version="2.0.2", python_version="3.10"
+    pkg_name="numpy", pkg_version="2.0.2", target=Target(python_version="3.10")
 )
 print(f"Closest valid version: {version}")
 ```

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -55,11 +55,11 @@ print(f"NumPy version: {version}")
 Find the closest valid package version for your Python version:
 
 ```python
-from feu.compat import find_closest_version, is_valid_version
+from feu.compat import Target, find_closest_version, is_valid_version
 
 # Check if a specific version is valid for your Python version
 is_valid = is_valid_version(
-    pkg_name="numpy", pkg_version="2.0.2", python_version="3.10"
+    pkg_name="numpy", pkg_version="2.0.2", target=Target(python_version="3.10")
 )
 print(f"NumPy 2.0.2 is valid for Python 3.10: {is_valid}")
 
@@ -67,7 +67,7 @@ print(f"NumPy 2.0.2 is valid for Python 3.10: {is_valid}")
 closest = find_closest_version(
     pkg_name="numpy",
     pkg_version="1.0.0",  # This is too old for Python 3.11
-    python_version="3.11",
+    target=Target(python_version="3.11"),
 )
 print(f"Closest valid version: {closest}")  # Will return "1.23.2"
 ```
@@ -99,26 +99,26 @@ install_package_closest_version(
 Add custom package configurations to the default compatibility registry:
 
 ```python
-from feu.compat import get_default_registry
+from feu.compat import Target, get_default_registry
 
 registry = get_default_registry()
 
 # Add a custom package configuration
 registry.register(
     pkg_name="my_package",
-    python_version="3.11",
+    target=Target(python_version="3.11"),
     pkg_version_min="1.2.0",
     pkg_version_max="2.0.0",
     exist_ok=True,
 )
 
 # Get the configuration for a package
-config = registry.get_config(pkg_name="my_package", python_version="3.11")
+config = registry.get_config(pkg_name="my_package", target=Target(python_version="3.11"))
 print(config)  # {'min': '1.2.0', 'max': '2.0.0'}
 
 # Get min and max versions
 min_version, max_version = registry.get_min_and_max_versions(
-    pkg_name="numpy", python_version="3.11"
+    pkg_name="numpy", target=Target(python_version="3.11")
 )
 print(f"Min: {min_version}, Max: {max_version}")
 ```
@@ -190,13 +190,13 @@ If you're maintaining a project that supports multiple Python versions:
 
 ```python
 import sys
-from feu.compat import find_closest_version
+from feu.compat import Target, find_closest_version
 
 python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 # Find compatible numpy version
 numpy_version = find_closest_version(
-    pkg_name="numpy", pkg_version="2.0.0", python_version=python_version
+    pkg_name="numpy", pkg_version="2.0.0", target=Target(python_version=python_version)
 )
 print(f"Installing numpy {numpy_version} for Python {python_version}")
 ```
@@ -207,7 +207,7 @@ Before installing a package, check if the version is compatible:
 
 ```python
 import sys
-from feu.compat import is_valid_version
+from feu.compat import Target, is_valid_version
 from feu import install_package
 from feu.utils.package import PackageSpec
 from feu.utils.installer import InstallerSpec
@@ -215,7 +215,7 @@ from feu.utils.installer import InstallerSpec
 python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
 desired_version = "2.0.2"
 
-if is_valid_version("numpy", desired_version, python_version):
+if is_valid_version("numpy", desired_version, Target(python_version=python_version)):
     install_package(
         installer=InstallerSpec(name="pip"),
         package=PackageSpec(name="numpy", version=desired_version),

--- a/docs/superpowers/plans/2026-07-31-multiaxis-compat-target.md
+++ b/docs/superpowers/plans/2026-07-31-multiaxis-compat-target.md
@@ -1,0 +1,1468 @@
+# Multi-axis Compat Target Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `python_version: str` key in `feu.compat` with a
+`Target(python_version, free_threaded, os, arch)` key, and split
+`CompatRegistry` into a base layer (defaults/discovered data) and an
+overrides layer (user corrections) that always wins and never
+conflicts with the base layer.
+
+**Architecture:** A new frozen `Target` dataclass becomes the registry
+key. `CompatRegistry` stores two `dict[str, dict[Target, dict[str, str
+| None]]]` tables (`_base`, `_overrides`). Lookups resolve against
+`_overrides` first using wildcard/specificity matching (unset
+`os`/`arch` on a stored entry matches any value; the most specific
+matching entry wins), falling back to `_base`. `register()` /
+`register_many()` take a `layer` parameter (`"base"` or `"override"`,
+default `"override"`) so `register_defaults()` can seed `_base` while
+the public `register_compat()` always writes to `_overrides`.
+
+**Tech Stack:** Python 3.10+ (repo baseline), `packaging` for version
+parsing, `pytest` for tests. No new dependencies.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-31-multiaxis-compat-target-design.md`
+- `discover_compat` keeps returning `dict[str, dict[str, str | None]]`
+  keyed by python-version string — it is NOT touched in this plan.
+- `Target.free_threaded` defaults to `False`; `Target.os`/`Target.arch`
+  default to `None` (wildcard).
+- `os`/`arch` on a *lookup* target are matched against a stored
+  entry's `os`/`arch` only when the stored entry specifies them
+  (non-`None`); `python_version` and `free_threaded` must always match
+  exactly.
+- A user override (`register_compat` / `register()` with default
+  `layer="override"`) must never conflict-check against `_base` —
+  `exist_ok=False` only raises for a collision within the same layer.
+- Every existing public symbol keeps working, just with `target:
+  Target` replacing `python_version: str` in signatures.
+
+---
+
+### Task 1: `Target` dataclass
+
+**Files:**
+- Create: `src/feu/compat/target.py`
+- Test: `tests/unit/compat/test_target.py`
+
+**Interfaces:**
+- Produces: `feu.compat.target.Target` — frozen dataclass with fields
+  `python_version: str`, `free_threaded: bool = False`, `os: str |
+  None = None`, `arch: str | None = None`. Hashable (usable as a dict
+  key) because it's frozen and all fields are hashable.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/compat/test_target.py
+from __future__ import annotations
+
+from feu.compat.target import Target
+
+
+def test_target_defaults() -> None:
+    target = Target(python_version="3.11")
+    assert target.python_version == "3.11"
+    assert target.free_threaded is False
+    assert target.os is None
+    assert target.arch is None
+
+
+def test_target_all_fields() -> None:
+    target = Target(python_version="3.14", free_threaded=True, os="macos", arch="arm64")
+    assert target.python_version == "3.14"
+    assert target.free_threaded is True
+    assert target.os == "macos"
+    assert target.arch == "arm64"
+
+
+def test_target_equality() -> None:
+    assert Target(python_version="3.11") == Target(python_version="3.11")
+    assert Target(python_version="3.11") != Target(python_version="3.12")
+    assert Target(python_version="3.11", os="linux") != Target(python_version="3.11")
+
+
+def test_target_is_hashable() -> None:
+    targets = {Target(python_version="3.11"), Target(python_version="3.11")}
+    assert len(targets) == 1
+    targets.add(Target(python_version="3.11", free_threaded=True))
+    assert len(targets) == 2
+
+
+def test_target_used_as_dict_key() -> None:
+    mapping = {Target(python_version="3.11"): "value"}
+    assert mapping[Target(python_version="3.11")] == "value"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/compat/test_target.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'feu.compat.target'`
+
+- [ ] **Step 3: Implement `Target`**
+
+```python
+# src/feu/compat/target.py
+r"""Define the compatibility target key used to look up package
+version constraints."""
+
+from __future__ import annotations
+
+__all__ = ["Target"]
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Target:
+    r"""Identify the environment a package compatibility constraint
+    applies to.
+
+    Args:
+        python_version: The Python version, e.g. ``"3.11"``.
+        free_threaded: ``True`` for a free-threaded (no-GIL) Python
+            build, e.g. ``3.14t``. Defaults to ``False``.
+        os: The operating system, e.g. ``"linux"``, ``"macos"``,
+            ``"windows"``. ``None`` means "any OS" when used as a
+            registry entry, and "unspecified" when used as a lookup
+            target.
+        arch: The CPU architecture, e.g. ``"x86_64"``, ``"arm64"``.
+            ``None`` means "any architecture" when used as a registry
+            entry, and "unspecified" when used as a lookup target.
+
+    Example:
+        ```pycon
+        >>> from feu.compat.target import Target
+        >>> Target(python_version="3.14", free_threaded=True, os="linux", arch="x86_64")
+        Target(python_version='3.14', free_threaded=True, os='linux', arch='x86_64')
+
+        ```
+    """
+
+    python_version: str
+    free_threaded: bool = False
+    os: str | None = None
+    arch: str | None = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/compat/test_target.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feu/compat/target.py tests/unit/compat/test_target.py
+git commit -m "feat(compat): add Target dataclass for multi-axis compat keys"
+```
+
+---
+
+### Task 2: Rewrite `CompatRegistry` with base/override layers and wildcard matching
+
+**Files:**
+- Modify: `src/feu/compat/registry.py` (full rewrite of `CompatRegistry`)
+- Test: `tests/unit/compat/test_registry.py` (full rewrite)
+
+**Interfaces:**
+- Consumes: `feu.compat.target.Target` (Task 1).
+- Produces:
+  - `CompatRegistry(initial_state: dict[str, dict[Target, dict[str,
+    str | None]]] | None = None)` — `initial_state` seeds the **base**
+    layer.
+  - `CompatRegistry.register(pkg_name: str, target: Target,
+    pkg_version_min: str | None, pkg_version_max: str | None,
+    exist_ok: bool = False, layer: str = "override") -> None`
+  - `CompatRegistry.register_many(mapping: dict[str, dict[Target,
+    dict[str, str | None]]], exist_ok: bool = False, layer: str =
+    "override") -> None`
+  - `CompatRegistry.get_config(pkg_name: str, target: Target) ->
+    dict[str, str | None]`
+  - `CompatRegistry.is_unsupported(pkg_name: str, target: Target) ->
+    bool`
+  - `CompatRegistry.get_min_and_max_versions(pkg_name: str, target:
+    Target) -> tuple[Version | None, Version | None]`
+  - `CompatRegistry.find_closest_version(pkg_name: str, pkg_version:
+    str, target: Target) -> str`
+  - `CompatRegistry.is_valid_version(pkg_name: str, pkg_version: str,
+    target: Target) -> bool`
+  - `CompatRegistry.base: dict[str, dict[Target, dict[str, str |
+    None]]]` and `CompatRegistry.overrides: dict[str, dict[Target,
+    dict[str, str | None]]]` — read-only-by-convention properties
+    exposing the two layers (used by tests and by `test_defaults.py`
+    in Task 3).
+  - `UNSUPPORTED`, `UnsupportedVersionError` — unchanged, re-exported
+    as before.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/compat/test_registry.py
+from __future__ import annotations
+
+import pytest
+from packaging.version import Version
+
+from feu.compat.registry import UNSUPPORTED, CompatRegistry, UnsupportedVersionError
+from feu.compat.target import Target
+
+T311 = Target(python_version="3.11")
+T310 = Target(python_version="3.10")
+T315 = Target(python_version="3.15")
+
+##################################
+#     Tests for CompatRegistry    #
+##################################
+
+
+def test_compat_registry_init_empty() -> None:
+    registry = CompatRegistry()
+    assert registry.base == {}
+    assert registry.overrides == {}
+
+
+def test_compat_registry_init_with_state() -> None:
+    registry = CompatRegistry({"numpy": {T311: {"min": "1.0.0", "max": None}}})
+    assert registry.base == {"numpy": {T311: {"min": "1.0.0", "max": None}}}
+    assert registry.overrides == {}
+
+
+def test_compat_registry_init_copies_state() -> None:
+    state = {"numpy": {T311: {"min": "1.0.0", "max": None}}}
+    registry = CompatRegistry(state)
+    registry.register("torch", T311, "2.0.0", None, layer="base")
+    assert "torch" not in state
+
+
+def test_compat_registry_repr() -> None:
+    registry = CompatRegistry()
+    assert repr(registry).startswith("CompatRegistry(")
+
+
+def test_compat_registry_str() -> None:
+    registry = CompatRegistry()
+    assert str(registry).startswith("CompatRegistry(")
+
+
+def test_compat_registry_register_default_layer_is_override() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.0.2")
+    assert registry.overrides == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
+    assert registry.base == {}
+
+
+def test_compat_registry_register_base_layer() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
+    assert registry.base == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
+    assert registry.overrides == {}
+
+
+def test_compat_registry_register_multiple() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
+    registry.register("my_package", T310, "1.1.0", "1.5.2", layer="base")
+    assert registry.base == {
+        "my_package": {
+            T311: {"min": "1.2.0", "max": "2.0.2"},
+            T310: {"min": "1.1.0", "max": "1.5.2"},
+        }
+    }
+
+
+def test_compat_registry_register_exist_ok_false_same_layer() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
+    with pytest.raises(
+        RuntimeError, match=r"A package configuration .* is already registered for package"
+    ):
+        registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
+
+
+def test_compat_registry_register_override_never_conflicts_with_base() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
+    # No exist_ok needed: override layer is independent of base layer.
+    registry.register("my_package", T311, "9.0.0", None)
+    assert registry.overrides == {"my_package": {T311: {"min": "9.0.0", "max": None}}}
+    assert registry.base == {"my_package": {T311: {"min": "1.1.0", "max": "1.5.2"}}}
+
+
+def test_compat_registry_register_exist_ok_true() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
+    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base", exist_ok=True)
+    assert registry.base == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
+
+
+def test_compat_registry_register_many() -> None:
+    registry = CompatRegistry()
+    registry.register_many(
+        {
+            "numpy": {T311: {"min": "1.23.2", "max": "2.4.6"}},
+            "torch": {T311: {"min": "2.0.0", "max": None}},
+        },
+        layer="base",
+    )
+    assert registry.base == {
+        "numpy": {T311: {"min": "1.23.2", "max": "2.4.6"}},
+        "torch": {T311: {"min": "2.0.0", "max": None}},
+    }
+
+
+def test_compat_registry_register_many_exist_ok_false() -> None:
+    registry = CompatRegistry()
+    registry.register_many({"numpy": {T311: {"min": "1.0.0", "max": None}}}, layer="base")
+    with pytest.raises(
+        RuntimeError, match=r"A package configuration .* is already registered for package"
+    ):
+        registry.register_many({"numpy": {T311: {"min": "2.0.0", "max": None}}}, layer="base")
+
+
+def test_compat_registry_register_many_exist_ok_true() -> None:
+    registry = CompatRegistry()
+    registry.register_many({"numpy": {T311: {"min": "1.0.0", "max": None}}}, layer="base")
+    registry.register_many(
+        {"numpy": {T311: {"min": "2.0.0", "max": None}}}, layer="base", exist_ok=True
+    )
+    assert registry.base == {"numpy": {T311: {"min": "2.0.0", "max": None}}}
+
+
+def test_compat_registry_get_config_override_wins_over_base() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    registry.register("my_package", T311, "2.0.0", None, layer="override")
+    assert registry.get_config(pkg_name="my_package", target=T311) == {
+        "min": "2.0.0",
+        "max": None,
+    }
+
+
+def test_compat_registry_get_config_falls_back_to_base() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    assert registry.get_config(pkg_name="my_package", target=T311) == {
+        "min": "1.0.0",
+        "max": None,
+    }
+
+
+def test_compat_registry_get_config_empty_registry() -> None:
+    registry = CompatRegistry()
+    assert registry.get_config(pkg_name="my_package", target=T311) == {}
+
+
+def test_compat_registry_get_config_no_matching_target() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T310, "1.0.0", None, layer="base")
+    assert registry.get_config(pkg_name="my_package", target=T311) == {}
+
+
+#############################################
+#     Tests for wildcard/specificity match   #
+#############################################
+
+
+def test_compat_registry_os_wildcard_matches_any_os() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    linux_target = Target(python_version="3.11", os="linux")
+    assert registry.get_config(pkg_name="my_package", target=linux_target) == {
+        "min": "1.0.0",
+        "max": None,
+    }
+
+
+def test_compat_registry_more_specific_entry_wins() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    registry.register(
+        "my_package",
+        Target(python_version="3.11", os="macos", arch="arm64"),
+        "5.0.0",
+        None,
+        layer="base",
+    )
+    macos_arm = Target(python_version="3.11", os="macos", arch="arm64")
+    linux = Target(python_version="3.11", os="linux")
+    assert registry.get_config(pkg_name="my_package", target=macos_arm) == {
+        "min": "5.0.0",
+        "max": None,
+    }
+    assert registry.get_config(pkg_name="my_package", target=linux) == {
+        "min": "1.0.0",
+        "max": None,
+    }
+
+
+def test_compat_registry_free_threaded_must_match_exactly() -> None:
+    registry = CompatRegistry()
+    registry.register(
+        "my_package", Target(python_version="3.14", free_threaded=True), "1.0.0", None,
+        layer="base",
+    )
+    non_free_threaded = Target(python_version="3.14", free_threaded=False)
+    assert registry.get_config(pkg_name="my_package", target=non_free_threaded) == {}
+
+
+def test_compat_registry_most_recent_wins_among_ties() -> None:
+    registry = CompatRegistry()
+    registry.register(
+        "my_package", Target(python_version="3.11", os="linux"), "1.0.0", None, layer="base"
+    )
+    registry.register(
+        "my_package", Target(python_version="3.11", arch="x86_64"), "2.0.0", None, layer="base"
+    )
+    target = Target(python_version="3.11", os="linux", arch="x86_64")
+    # Both entries match with equal specificity (one non-None field each);
+    # the most recently registered one wins.
+    assert registry.get_config(pkg_name="my_package", target=target) == {
+        "min": "2.0.0",
+        "max": None,
+    }
+
+
+########################################
+#     Tests for min/max/closest/valid  #
+########################################
+
+
+def test_compat_registry_get_min_and_max_versions() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert registry.get_min_and_max_versions(pkg_name="my_package", target=T311) == (
+        Version("1.2.0"),
+        Version("2.2.0"),
+    )
+
+
+def test_compat_registry_get_min_and_max_versions_empty() -> None:
+    registry = CompatRegistry()
+    assert registry.get_min_and_max_versions(pkg_name="my_package", target=T311) == (None, None)
+
+
+def test_compat_registry_find_closest_version_valid() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert (
+        registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
+        == "2.0.0"
+    )
+
+
+def test_compat_registry_find_closest_version_missing() -> None:
+    registry = CompatRegistry()
+    assert (
+        registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
+        == "2.0.0"
+    )
+
+
+def test_compat_registry_find_closest_version_lower() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert (
+        registry.find_closest_version(pkg_name="my_package", pkg_version="1.0.0", target=T311)
+        == "1.2.0"
+    )
+
+
+def test_compat_registry_find_closest_version_higher() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert (
+        registry.find_closest_version(pkg_name="my_package", pkg_version="3.0.0", target=T311)
+        == "2.2.0"
+    )
+
+
+def test_compat_registry_is_valid_version_true() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
+
+
+def test_compat_registry_is_valid_version_false_min() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert not registry.is_valid_version(pkg_name="my_package", pkg_version="1.0.0", target=T311)
+
+
+def test_compat_registry_is_valid_version_false_max() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert not registry.is_valid_version(pkg_name="my_package", pkg_version="3.0.0", target=T311)
+
+
+def test_compat_registry_is_valid_version_empty() -> None:
+    registry = CompatRegistry()
+    assert registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
+
+
+###################################
+#     Tests for UNSUPPORTED       #
+###################################
+
+
+def test_compat_registry_is_unsupported_true() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    assert registry.is_unsupported(pkg_name="my_package", target=T315)
+
+
+def test_compat_registry_is_unsupported_false() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert not registry.is_unsupported(pkg_name="my_package", target=T311)
+
+
+def test_compat_registry_is_unsupported_unconfigured() -> None:
+    registry = CompatRegistry()
+    assert not registry.is_unsupported(pkg_name="my_package", target=T311)
+
+
+def test_compat_registry_get_min_and_max_versions_unsupported_raises() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    with pytest.raises(UnsupportedVersionError, match=r"No version of package my_package"):
+        registry.get_min_and_max_versions(pkg_name="my_package", target=T315)
+
+
+def test_compat_registry_find_closest_version_unsupported_raises() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    with pytest.raises(UnsupportedVersionError, match=r"No version of package my_package"):
+        registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T315)
+
+
+def test_compat_registry_is_valid_version_unsupported_false() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    assert not registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T315)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/compat/test_registry.py -v`
+Expected: FAIL — `CompatRegistry` still uses the old `python_version:
+str` / single-table API (`AttributeError`/`TypeError` on `.base`,
+`register(layer=...)`, `get_config(target=...)`, etc).
+
+- [ ] **Step 3: Rewrite `CompatRegistry`**
+
+```python
+# src/feu/compat/registry.py
+r"""Define the compatibility registry for package version resolution.
+
+This module provides a registry system that manages and resolves valid
+package version ranges per compatibility target, enabling lookup of
+the closest valid version and validation of a given version.
+"""
+
+from __future__ import annotations
+
+__all__ = ["UNSUPPORTED", "CompatRegistry", "UnsupportedVersionError"]
+
+import copy
+from typing import Literal
+
+from packaging.version import Version
+
+from feu.compat.target import Target
+
+UNSUPPORTED = "unsupported"
+r"""Sentinel used as the ``min``/``max`` value to mark a target for
+which no package version is valid.
+
+This is distinct from ``None``, which means "unconstrained" (i.e. any
+version is valid).
+"""
+
+_Layer = Literal["base", "override"]
+
+
+class UnsupportedVersionError(Exception):
+    r"""Raised when no package version is compatible with a given
+    target."""
+
+
+class CompatRegistry:
+    r"""Manage package version compatibility across different
+    compatibility targets.
+
+    The registry holds two independent layers per package:
+
+    - ``base``: populated by ``register_defaults`` and discovered
+      data. Entries here can be freely refreshed (e.g. by re-running
+      discovery) without ever conflicting with user overrides.
+    - ``overrides``: populated by user calls (``register_compat`` /
+      ``register(layer="override")``, the default). Overrides always
+      take precedence over ``base`` and are only conflict-checked
+      against other overrides.
+
+    Each layer maps package name to ``Target`` to ``{"min": ...,
+    "max": ...}``. A lookup target matches a stored entry when
+    ``python_version`` and ``free_threaded`` are equal, and the
+    stored entry's ``os``/``arch`` are either ``None`` (wildcard) or
+    equal to the lookup target's ``os``/``arch``. Among all matching
+    entries in a layer, the most specific one (most non-``None``
+    ``os``/``arch`` fields) wins; ties are broken by most-recently
+    registered.
+
+    Args:
+        initial_state: Optional initial mapping of package
+            constraints, seeding the ``base`` layer. If provided, the
+            state is copied to prevent external mutations.
+
+    Example:
+        ```pycon
+        >>> from feu.compat import CompatRegistry, Target
+        >>> registry = CompatRegistry()
+        >>> registry.register(
+        ...     pkg_name="numpy",
+        ...     target=Target(python_version="3.11"),
+        ...     pkg_version_min="1.23.2",
+        ...     pkg_version_max="2.4.6",
+        ...     layer="base",
+        ... )
+        >>> registry.is_valid_version("numpy", "2.0.2", Target(python_version="3.11"))
+        True
+
+        ```
+    """
+
+    def __init__(
+        self, initial_state: dict[str, dict[Target, dict[str, str | None]]] | None = None
+    ) -> None:
+        self._base: dict[str, dict[Target, dict[str, str | None]]] = copy.deepcopy(
+            initial_state or {}
+        )
+        self._overrides: dict[str, dict[Target, dict[str, str | None]]] = {}
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__qualname__}(\n"
+            f"  (base): {self._base}\n"
+            f"  (overrides): {self._overrides}\n)"
+        )
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    @property
+    def base(self) -> dict[str, dict[Target, dict[str, str | None]]]:
+        r"""The base layer (defaults/discovered data)."""
+        return self._base
+
+    @property
+    def overrides(self) -> dict[str, dict[Target, dict[str, str | None]]]:
+        r"""The override layer (user-supplied corrections)."""
+        return self._overrides
+
+    def _layer_table(self, layer: _Layer) -> dict[str, dict[Target, dict[str, str | None]]]:
+        return self._base if layer == "base" else self._overrides
+
+    def register(
+        self,
+        pkg_name: str,
+        target: Target,
+        pkg_version_min: str | None,
+        pkg_version_max: str | None,
+        exist_ok: bool = False,
+        layer: _Layer = "override",
+    ) -> None:
+        r"""Register a package configuration for a compatibility
+        target.
+
+        Args:
+            pkg_name: The package name to register (e.g., ``"numpy"``).
+            target: The compatibility target.
+            pkg_version_min: The minimum valid package version for
+                this target, or ``None`` for no minimum.
+            pkg_version_max: The maximum valid package version for
+                this target, or ``None`` for no maximum.
+            exist_ok: If ``False``, a ``RuntimeError`` is raised when a
+                configuration already exists for this package and
+                target **within the same layer**. Set to ``True`` to
+                overwrite.
+            layer: Which layer to write to, ``"base"`` or
+                ``"override"``. Defaults to ``"override"``, matching
+                the public ``register_compat`` behavior.
+
+        Raises:
+            RuntimeError: If a configuration already exists for the
+                given package name and target in the same layer, and
+                ``exist_ok`` is ``False``.
+        """
+        table = self._layer_table(layer)
+        table[pkg_name] = table.get(pkg_name, {})
+
+        if target in table[pkg_name] and not exist_ok:
+            msg = (
+                f"A package configuration ({table[pkg_name][target]}) is already "
+                f"registered for package {pkg_name} and target {target} in the "
+                f"'{layer}' layer. Please use `exist_ok=True` if you want to "
+                f"overwrite the package config"
+            )
+            raise RuntimeError(msg)
+
+        table[pkg_name][target] = {"min": pkg_version_min, "max": pkg_version_max}
+
+    def register_many(
+        self,
+        mapping: dict[str, dict[Target, dict[str, str | None]]],
+        exist_ok: bool = False,
+        layer: _Layer = "override",
+    ) -> None:
+        r"""Register multiple package configurations at once.
+
+        Args:
+            mapping: Mapping of package name to ``Target`` to
+                ``{"min": ..., "max": ...}`` constraints.
+            exist_ok: Forwarded to ``register``.
+            layer: Forwarded to ``register``.
+        """
+        for pkg_name, targets in mapping.items():
+            for target, config in targets.items():
+                self.register(
+                    pkg_name=pkg_name,
+                    target=target,
+                    pkg_version_min=config.get("min"),
+                    pkg_version_max=config.get("max"),
+                    exist_ok=exist_ok,
+                    layer=layer,
+                )
+
+    @staticmethod
+    def _matches(entry_target: Target, lookup: Target) -> bool:
+        if entry_target.python_version != lookup.python_version:
+            return False
+        if entry_target.free_threaded != lookup.free_threaded:
+            return False
+        if entry_target.os is not None and entry_target.os != lookup.os:
+            return False
+        return not (entry_target.arch is not None and entry_target.arch != lookup.arch)
+
+    @staticmethod
+    def _specificity(entry_target: Target) -> int:
+        return (entry_target.os is not None) + (entry_target.arch is not None)
+
+    def _resolve_in_layer(
+        self, table: dict[str, dict[Target, dict[str, str | None]]], pkg_name: str, target: Target
+    ) -> dict[str, str | None] | None:
+        if pkg_name not in table:
+            return None
+        best: dict[str, str | None] | None = None
+        best_specificity = -1
+        for entry_target, config in table[pkg_name].items():
+            if not self._matches(entry_target, target):
+                continue
+            specificity = self._specificity(entry_target)
+            if specificity >= best_specificity:
+                best_specificity = specificity
+                best = config
+        return best
+
+    def get_config(self, pkg_name: str, target: Target) -> dict[str, str | None]:
+        r"""Get the package version configuration for a package and
+        compatibility target.
+
+        Checks the override layer first, then falls back to the base
+        layer.
+
+        Args:
+            pkg_name: The package name to query (e.g., ``"numpy"``).
+            target: The compatibility target.
+
+        Returns:
+            A dictionary with ``"min"`` and ``"max"`` keys, or an
+            empty dictionary if no configuration matches.
+        """
+        config = self._resolve_in_layer(self._overrides, pkg_name, target)
+        if config is not None:
+            return config
+        return self._resolve_in_layer(self._base, pkg_name, target) or {}
+
+    def is_unsupported(self, pkg_name: str, target: Target) -> bool:
+        r"""Indicate if no package version is valid for a target.
+
+        Args:
+            pkg_name: The package name to check (e.g., ``"numpy"``).
+            target: The compatibility target.
+
+        Returns:
+            ``True`` if the package has no valid version for the
+            given target, ``False`` otherwise.
+        """
+        config = self.get_config(pkg_name=pkg_name, target=target)
+        return config.get("min") == UNSUPPORTED or config.get("max") == UNSUPPORTED
+
+    def get_min_and_max_versions(
+        self, pkg_name: str, target: Target
+    ) -> tuple[Version | None, Version | None]:
+        r"""Get the minimum and maximum versions as ``Version``
+        objects.
+
+        Args:
+            pkg_name: The package name to query (e.g., ``"numpy"``).
+            target: The compatibility target.
+
+        Returns:
+            A tuple ``(min_version, max_version)``, either value being
+            ``None`` if unconstrained or unconfigured.
+
+        Raises:
+            UnsupportedVersionError: If no package version is valid
+                for the given target.
+        """
+        if self.is_unsupported(pkg_name=pkg_name, target=target):
+            msg = f"No version of package {pkg_name} is compatible with target {target}"
+            raise UnsupportedVersionError(msg)
+        config = self.get_config(pkg_name=pkg_name, target=target)
+        min_version = config.get("min", None)
+        max_version = config.get("max", None)
+        if min_version is not None:
+            min_version = Version(min_version)
+        if max_version is not None:
+            max_version = Version(max_version)
+        return min_version, max_version
+
+    def find_closest_version(self, pkg_name: str, pkg_version: str, target: Target) -> str:
+        r"""Find the closest valid version for a package.
+
+        Args:
+            pkg_name: The package name to check (e.g., ``"numpy"``).
+            pkg_version: The requested package version.
+            target: The compatibility target.
+
+        Returns:
+            The closest valid version as a string.
+
+        Raises:
+            UnsupportedVersionError: If no package version is valid
+                for the given target.
+        """
+        version = Version(pkg_version)
+        min_version, max_version = self.get_min_and_max_versions(pkg_name=pkg_name, target=target)
+        if min_version is not None and version < min_version:
+            return min_version.base_version
+        if max_version is not None and version > max_version:
+            return max_version.base_version
+        return pkg_version
+
+    def is_valid_version(self, pkg_name: str, pkg_version: str, target: Target) -> bool:
+        r"""Check if a package version is valid for a target.
+
+        Args:
+            pkg_name: The package name to check (e.g., ``"numpy"``).
+            pkg_version: The package version to validate.
+            target: The compatibility target.
+
+        Returns:
+            ``True`` if valid or unconfigured, ``False`` otherwise,
+            including when no package version is valid for the given
+            target.
+        """
+        if self.is_unsupported(pkg_name=pkg_name, target=target):
+            return False
+        version = Version(pkg_version)
+        min_version, max_version = self.get_min_and_max_versions(pkg_name=pkg_name, target=target)
+        return (min_version is None or min_version <= version) and (
+            max_version is None or version <= max_version
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/compat/test_registry.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feu/compat/registry.py tests/unit/compat/test_registry.py
+git commit -m "feat(compat): rewrite CompatRegistry with base/override layers and Target keys"
+```
+
+---
+
+### Task 3: Update `defaults.py` to load into the base layer via `Target`
+
+**Files:**
+- Modify: `src/feu/compat/defaults.py`
+- Modify: `tests/unit/compat/test_defaults.py`
+
+**Interfaces:**
+- Consumes: `CompatRegistry.register_many(mapping, layer="base")`
+  (Task 2), `Target` (Task 1).
+- Produces: `register_defaults(registry: CompatRegistry) -> None` —
+  unchanged signature, now writes to the base layer with `Target`
+  keys built from `DEFAULT_COMPAT`'s existing
+  `dict[pkg][python_version_str]` shape. `DEFAULT_COMPAT` itself is
+  **not** changed in shape (stays `dict[str, dict[str, dict[str, str |
+  None]]]`) so `dev/discover_compat.py`'s source-rewriting logic keeps
+  working untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/compat/test_defaults.py
+from __future__ import annotations
+
+from feu.compat.defaults import DEFAULT_COMPAT, register_defaults
+from feu.compat.registry import CompatRegistry
+from feu.compat.target import Target
+
+#############################################
+#     Tests for register_defaults           #
+#############################################
+
+
+def test_register_defaults_populates_base_layer() -> None:
+    registry = CompatRegistry()
+    register_defaults(registry)
+    assert registry.overrides == {}
+    assert registry.base["numpy"][Target(python_version="3.11")] == {
+        "min": "1.23.2",
+        "max": "2.4.6",
+    }
+
+
+def test_register_defaults_numpy_entry() -> None:
+    registry = CompatRegistry()
+    register_defaults(registry)
+    assert registry.get_config(pkg_name="numpy", target=Target(python_version="3.11")) == {
+        "min": "1.23.2",
+        "max": "2.4.6",
+    }
+
+
+def test_default_compat_contains_expected_packages() -> None:
+    assert set(DEFAULT_COMPAT.keys()) == {
+        "click",
+        "duckdb",
+        "jax",
+        "matplotlib",
+        "numpy",
+        "pandas",
+        "pyarrow",
+        "pydantic",
+        "requests",
+        "scikit-learn",
+        "scipy",
+        "torch",
+        "xarray",
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/compat/test_defaults.py -v`
+Expected: FAIL — `register_defaults` still calls
+`registry.register_many(DEFAULT_COMPAT)` with string keys, which now
+raises/mismatches since `register_many` expects `Target` keys and the
+old test attributes (`registry.registry`) no longer exist.
+
+- [ ] **Step 3: Update `register_defaults`**
+
+Only the last function in the file changes; `DEFAULT_COMPAT` itself is
+untouched.
+
+```python
+# src/feu/compat/defaults.py — replace the closing function only
+def register_defaults(registry: CompatRegistry) -> None:
+    r"""Populate a registry's base layer with the default package
+    compatibility constraints.
+
+    Args:
+        registry: The registry to populate.
+    """
+    mapping: dict[str, dict[Target, dict[str, str | None]]] = {
+        pkg_name: {
+            Target(python_version=python_version): config
+            for python_version, config in versions.items()
+        }
+        for pkg_name, versions in DEFAULT_COMPAT.items()
+    }
+    registry.register_many(mapping, layer="base")
+```
+
+Add the import at the top of the file (next to the existing
+`TYPE_CHECKING` import block):
+
+```python
+from feu.compat.target import Target
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/compat/test_defaults.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feu/compat/defaults.py tests/unit/compat/test_defaults.py
+git commit -m "feat(compat): load DEFAULT_COMPAT into the registry base layer as Targets"
+```
+
+---
+
+### Task 4: Update `interface.py` and package `__init__.py` exports
+
+**Files:**
+- Modify: `src/feu/compat/interface.py`
+- Modify: `src/feu/compat/__init__.py`
+- Modify: `tests/unit/compat/test_interface.py`
+
+**Interfaces:**
+- Consumes: `Target` (Task 1), updated `CompatRegistry` (Task 2),
+  updated `register_defaults` (Task 3).
+- Produces:
+  - `get_default_registry() -> CompatRegistry` — unchanged.
+  - `register_compat(mapping: dict[str, dict[Target, dict[str, str |
+    None]]], exist_ok: bool = False) -> None` — delegates to
+    `get_default_registry().register_many(mapping, exist_ok=exist_ok)`
+    (default `layer="override"` from `register_many`).
+  - `find_closest_version(pkg_name: str, pkg_version: str, target:
+    Target) -> str`
+  - `is_valid_version(pkg_name: str, pkg_version: str, target: Target)
+    -> bool`
+  - `feu.compat.__init__` re-exports `Target` in addition to the
+    existing symbols.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/compat/test_interface.py
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from feu.compat.interface import (
+    find_closest_version,
+    get_default_registry,
+    is_valid_version,
+    register_compat,
+)
+from feu.compat.registry import CompatRegistry
+from feu.compat.target import Target
+
+T311 = Target(python_version="3.11")
+
+######################################
+#     Tests for get_default_registry #
+######################################
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_registry() -> None:
+    if hasattr(get_default_registry, "_registry"):
+        del get_default_registry._registry
+    yield
+    if hasattr(get_default_registry, "_registry"):
+        del get_default_registry._registry
+
+
+def test_get_default_registry_returns_compat_registry() -> None:
+    registry = get_default_registry()
+    assert isinstance(registry, CompatRegistry)
+
+
+def test_get_default_registry_is_singleton() -> None:
+    registry1 = get_default_registry()
+    registry2 = get_default_registry()
+    assert registry1 is registry2
+
+
+def test_get_default_registry_populated_with_defaults() -> None:
+    registry = get_default_registry()
+    assert registry.get_config(pkg_name="numpy", target=T311) == {
+        "min": "1.23.2",
+        "max": "2.4.6",
+    }
+
+
+#################################
+#     Tests for register_compat #
+#################################
+
+
+def test_register_compat_adds_to_override_layer() -> None:
+    register_compat({"my_package": {T311: {"min": "1.0.0", "max": None}}})
+    registry = get_default_registry()
+    assert registry.get_config(pkg_name="my_package", target=T311) == {
+        "min": "1.0.0",
+        "max": None,
+    }
+    assert registry.overrides == {"my_package": {T311: {"min": "1.0.0", "max": None}}}
+
+
+def test_register_compat_exist_ok_false_raises() -> None:
+    register_compat({"my_package": {T311: {"min": "1.0.0", "max": None}}})
+    with pytest.raises(RuntimeError, match=r"A package configuration .* is already registered"):
+        register_compat({"my_package": {T311: {"min": "2.0.0", "max": None}}})
+
+
+def test_register_compat_overrides_a_default_without_exist_ok() -> None:
+    # numpy has a base entry for 3.11; overriding it must not require exist_ok=True.
+    register_compat({"numpy": {T311: {"min": "9.9.9", "max": None}}})
+    assert get_default_registry().get_config(pkg_name="numpy", target=T311) == {
+        "min": "9.9.9",
+        "max": None,
+    }
+
+
+########################################
+#     Tests for find_closest_version   #
+########################################
+
+
+def test_find_closest_version_delegates_to_default_registry() -> None:
+    with patch.object(CompatRegistry, "find_closest_version", return_value="1.2.3") as mock_find:
+        result = find_closest_version(pkg_name="numpy", pkg_version="2.0.2", target=T311)
+    assert result == "1.2.3"
+    mock_find.assert_called_once_with(pkg_name="numpy", pkg_version="2.0.2", target=T311)
+
+
+def test_find_closest_version_uses_defaults() -> None:
+    assert find_closest_version(pkg_name="numpy", pkg_version="0.1.0", target=T311) == "1.23.2"
+
+
+##################################
+#     Tests for is_valid_version #
+##################################
+
+
+def test_is_valid_version_delegates_to_default_registry() -> None:
+    with patch.object(CompatRegistry, "is_valid_version", return_value=False) as mock_valid:
+        result = is_valid_version(pkg_name="numpy", pkg_version="2.0.2", target=T311)
+    assert result is False
+    mock_valid.assert_called_once_with(pkg_name="numpy", pkg_version="2.0.2", target=T311)
+
+
+def test_is_valid_version_uses_defaults() -> None:
+    assert not is_valid_version(pkg_name="numpy", pkg_version="0.1.0", target=T311)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/unit/compat/test_interface.py -v`
+Expected: FAIL — current `interface.py` functions take
+`python_version: str`, not `target: Target`.
+
+- [ ] **Step 3: Update `interface.py`**
+
+Replace every `python_version: str` parameter with `target: Target`
+and update the docstrings/examples accordingly:
+
+```python
+# src/feu/compat/interface.py
+r"""Define the public interface for package/target compatibility
+resolution."""
+
+from __future__ import annotations
+
+__all__ = [
+    "find_closest_version",
+    "get_default_registry",
+    "is_valid_version",
+    "register_compat",
+]
+
+from feu.compat.defaults import register_defaults
+from feu.compat.registry import CompatRegistry
+from feu.compat.target import Target
+
+
+def get_default_registry() -> CompatRegistry:
+    r"""Return the default global compatibility registry.
+
+    The registry is created on the first call and reused on all
+    subsequent calls (singleton pattern). It is pre-configured with
+    the default package version constraints in its base layer.
+
+    Returns:
+        A singleton ``CompatRegistry`` configured with the default
+        package version constraints.
+
+    Example:
+        ```pycon
+        >>> from feu.compat import get_default_registry, Target
+        >>> registry = get_default_registry()
+        >>> registry.is_valid_version("numpy", "2.0.2", Target(python_version="3.11"))
+        True
+
+        ```
+    """
+    if not hasattr(get_default_registry, "_registry"):
+        registry = CompatRegistry()
+        register_defaults(registry)
+        get_default_registry._registry = registry
+    return get_default_registry._registry
+
+
+def register_compat(
+    mapping: dict[str, dict[Target, dict[str, str | None]]],
+    exist_ok: bool = False,
+) -> None:
+    r"""Register custom package configurations into the default global
+    registry's override layer.
+
+    Override entries always take precedence over the default/base
+    layer, and are only conflict-checked against other overrides, so
+    correcting an inaccurate default never requires ``exist_ok=True``.
+
+    Args:
+        mapping: Mapping of package name to ``Target`` to
+            ``{"min": ..., "max": ...}`` constraints.
+        exist_ok: If ``False`` (default), raises an error if any entry
+            is already registered as an override. If ``True``,
+            overwrites existing override registrations silently.
+
+    Raises:
+        RuntimeError: If any entry is already registered as an
+            override and ``exist_ok`` is ``False``.
+
+    Example:
+        ```pycon
+        >>> from feu.compat import register_compat, Target
+        >>> register_compat(
+        ...     {"my_package": {Target(python_version="3.11"): {"min": "1.0.0", "max": None}}}
+        ... )
+
+        ```
+    """
+    get_default_registry().register_many(mapping, exist_ok=exist_ok)
+
+
+def find_closest_version(pkg_name: str, pkg_version: str, target: Target) -> str:
+    r"""Find the closest valid version for a package using the default
+    registry.
+
+    Args:
+        pkg_name: The package name to check (e.g., ``"numpy"``).
+        pkg_version: The requested package version.
+        target: The compatibility target.
+
+    Returns:
+        The closest valid version as a string.
+
+    Example:
+        ```pycon
+        >>> from feu.compat import find_closest_version, Target
+        >>> find_closest_version(
+        ...     pkg_name="numpy", pkg_version="2.0.2", target=Target(python_version="3.11")
+        ... )
+        '2.0.2'
+
+        ```
+    """
+    return get_default_registry().find_closest_version(
+        pkg_name=pkg_name, pkg_version=pkg_version, target=target
+    )
+
+
+def is_valid_version(pkg_name: str, pkg_version: str, target: Target) -> bool:
+    r"""Check if a package version is valid for a target using the
+    default registry.
+
+    Args:
+        pkg_name: The package name to check (e.g., ``"numpy"``).
+        pkg_version: The package version to validate.
+        target: The compatibility target.
+
+    Returns:
+        ``True`` if valid or unconfigured, ``False`` otherwise.
+
+    Example:
+        ```pycon
+        >>> from feu.compat import is_valid_version, Target
+        >>> is_valid_version(
+        ...     pkg_name="numpy", pkg_version="2.0.2", target=Target(python_version="3.11")
+        ... )
+        True
+
+        ```
+    """
+    return get_default_registry().is_valid_version(
+        pkg_name=pkg_name, pkg_version=pkg_version, target=target
+    )
+```
+
+Update `src/feu/compat/__init__.py` to also export `Target`:
+
+```python
+# src/feu/compat/__init__.py
+r"""Contain a registry-based system for package/target compatibility
+resolution."""
+
+from __future__ import annotations
+
+__all__ = [
+    "UNSUPPORTED",
+    "CompatRegistry",
+    "Target",
+    "UnsupportedVersionError",
+    "discover_compat",
+    "find_closest_version",
+    "get_default_registry",
+    "is_valid_version",
+    "register_compat",
+]
+
+from feu.compat.discovery import discover_compat
+from feu.compat.interface import (
+    find_closest_version,
+    get_default_registry,
+    is_valid_version,
+    register_compat,
+)
+from feu.compat.registry import UNSUPPORTED, CompatRegistry, UnsupportedVersionError
+from feu.compat.target import Target
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/unit/compat/ -v`
+Expected: PASS (all tests in the `compat` unit test directory,
+including Tasks 1-3's tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feu/compat/interface.py src/feu/compat/__init__.py tests/unit/compat/test_interface.py
+git commit -m "feat(compat): migrate public interface to Target-based signatures"
+```
+
+---
+
+### Task 5: Update `feu.install` callsite
+
+**Files:**
+- Modify: `src/feu/install/utils.py:79-83`
+- Modify: `tests/unit/install/test_utils.py` (only the assertions that
+  check `find_closest_version` call args, if any patch/mock it
+  directly — otherwise no changes needed since it's exercised via
+  `install_package_closest_version` end to end)
+
+**Interfaces:**
+- Consumes: `feu.compat.Target`, `feu.compat.find_closest_version(pkg_name,
+  pkg_version, target)` (Task 4).
+- Produces: `install_package_closest_version` behavior unchanged
+  externally.
+
+- [ ] **Step 1: Check for existing tests that assert on
+  `find_closest_version` call arguments**
+
+Run: `grep -n "find_closest_version" tests/unit/install/test_utils.py`
+
+If this returns no matches, the existing behavioral tests for
+`install_package_closest_version` (which exercise the real default
+registry end-to-end) will simply keep passing once the callsite is
+updated — proceed to Step 2. If it does return matches, update those
+assertions to expect a `Target` instead of a bare string, following
+the same pattern as Task 4's `mock_find.assert_called_once_with(...)`
+update.
+
+- [ ] **Step 2: Update the callsite**
+
+```python
+# src/feu/install/utils.py
+```
+
+Change the import block:
+
+```python
+from feu.compat import Target, find_closest_version
+```
+
+Change the call inside `install_package_closest_version`:
+
+```python
+    install_package(
+        installer=installer,
+        package=package.with_version(
+            find_closest_version(
+                pkg_name=package.name,
+                pkg_version=pkg_version,
+                target=Target(python_version=get_python_major_minor()),
+            )
+        ),
+    )
+```
+
+- [ ] **Step 3: Run the install unit tests**
+
+Run: `pytest tests/unit/install/ -v`
+Expected: PASS (no behavioral change — `Target(python_version=X)` with
+default `free_threaded=False, os=None, arch=None` resolves identically
+to the old `python_version=X` string lookups)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/feu/install/utils.py
+git commit -m "refactor(install): pass a Target to find_closest_version"
+```
+
+---
+
+### Task 6: Full test suite, lint, and doctest verification
+
+**Files:** none created/modified (verification-only task); fix
+whatever the checks below surface.
+
+- [ ] **Step 1: Run the full unit + integration test suite**
+
+Run: `pytest tests/unit tests/integration -v`
+Expected: PASS. If `tests/integration/compat/test_discovery.py` or any
+other test fails, inspect it — `discover_compat` itself is unchanged
+in this plan, so a failure there indicates a missed update in
+`register_defaults`/`interface.py`; fix and re-run.
+
+- [ ] **Step 2: Run doctests for the touched modules**
+
+Run: `pytest --doctest-modules src/feu/compat -v`
+Expected: PASS. This exercises every `>>>` example updated in Tasks
+1-4.
+
+- [ ] **Step 3: Run the project linter**
+
+Run: `ruff check src/feu/compat src/feu/install/utils.py tests/unit/compat tests/unit/install`
+Expected: no errors. Fix any import-order or unused-import issues
+(e.g. leftover `python_version` references) directly.
+
+- [ ] **Step 4: Grep for any leftover `python_version=` compat call
+  sites outside the discovery module**
+
+Run: `grep -rn "python_version=" src/feu tests | grep -v "feu/compat/discovery.py\|feu/version\|test_discovery.py"`
+Expected: no output. Anything printed here is a callsite that still
+passes the old string-based signature and needs updating using the
+same `Target(python_version=...)` pattern as Task 5.
+
+- [ ] **Step 5: Commit (only if Steps 1-4 required fixes)**
+
+```bash
+git add -A
+git commit -m "test(compat): fix remaining call sites after Target migration"
+```
+
+If no fixes were needed, skip this commit — there is nothing to
+record.
+
+---
+
+## Post-plan follow-ups (not part of this plan)
+
+- `dev/discover_compat.py` / `discover_compat()` still only produce
+  python-version-keyed data. A follow-up could extend discovery to
+  inspect actual wheel filenames per release to auto-populate
+  `os`/`arch`/`free_threaded` axes in the base layer.
+- `docs/docs/refs/compat.md` is a stub (15 bytes) and was not expanded
+  as part of this plan; consider documenting `Target` and the
+  base/override layering there separately.

--- a/docs/superpowers/specs/2026-07-31-multiaxis-compat-target-design.md
+++ b/docs/superpowers/specs/2026-07-31-multiaxis-compat-target-design.md
@@ -1,0 +1,163 @@
+# Multi-axis Compatibility Targets with Layered Overrides
+
+Date: 2026-07-31
+
+## Problem
+
+`feu.compat` currently keys compatibility constraints on a single Python
+version string (e.g. `"3.11"`). This can't express:
+
+- Free-threaded builds (e.g. `3.14t`), which some packages don't ship
+  wheels for yet.
+- OS (Linux / macOS / Windows) and architecture (x86_64 / arm64)
+  differences, since some packages only publish wheels for specific
+  platforms.
+
+Additionally, `discover_compat` derives constraints from PyPI
+`requires_python` metadata, which isn't always accurate. There is
+currently no clean way to let user-supplied corrections coexist with
+(and take precedence over) auto-discovered/default data without
+overwriting it in the same flat dict.
+
+## Goals
+
+- Support Python version, free-threaded, OS, and architecture as
+  independent axes of a compatibility "target".
+- Allow entries to be registered at any level of specificity (e.g. a
+  blanket rule for `python_version="3.14"`, plus a narrower override
+  for `python_version="3.14", free_threaded=True, os="macos"`).
+- Let user-registered corrections always take precedence over
+  defaults/discovered data, and never conflict with them, so a
+  discovery refresh never silently clobbers a user correction.
+
+## Non-goals
+
+- Changing `discover_compat` to inspect actual wheel filenames to
+  auto-detect free-threaded/OS/arch support. It continues to derive
+  constraints from `requires_python` only, producing
+  python-version-only entries. Wheel-tag-based discovery is a
+  candidate follow-up, not part of this change.
+- Plumbing OS/arch/free-threaded detection through `feu.install`
+  (`PackageSpec`, `InstallerSpec`, the pip resolver) to automatically
+  build a fully-populated `Target` at install time. The install
+  callsite is updated only to pass an equivalent `Target` for its
+  current python-version-only lookup.
+
+## Design
+
+### `Target`
+
+A new frozen dataclass in `feu/compat/target.py`:
+
+```python
+@dataclass(frozen=True)
+class Target:
+    python_version: str
+    free_threaded: bool = False
+    os: str | None = None      # e.g. "linux", "macos", "windows"; None = wildcard
+    arch: str | None = None    # e.g. "x86_64", "arm64"; None = wildcard
+```
+
+`os`/`arch` default to `None`, meaning "unspecified / matches
+anything". `free_threaded` defaults to `False`. `Target` replaces the
+`python_version: str` parameter across the registry and public API.
+
+### Wildcard matching and specificity
+
+`CompatRegistry` stores entries per package as `dict[Target, {"min":
+..., "max": ...}]`. When resolving a lookup target, an entry matches
+if every one of its non-`None`/non-default fields equals the
+corresponding lookup field:
+
+- `python_version` must match exactly (always required).
+- `free_threaded` must match exactly (always required — `False` is a
+  real value, not a wildcard, since it's the default for the vast
+  majority of environments).
+- `os` matches if the entry's `os` is `None` or equal to the lookup's
+  `os`.
+- `arch` matches if the entry's `arch` is `None` or equal to the
+  lookup's `arch`.
+
+Among all matching entries, the most specific one wins: the entry
+with the greater count of non-`None` `os`/`arch` fields. If multiple
+entries tie in specificity, the override layer takes precedence, and
+within the same layer the most recently registered entry wins.
+
+### Two-layer registry
+
+`CompatRegistry` holds two independent tables:
+
+```python
+self._base: dict[str, dict[Target, dict[str, str | None]]]
+self._overrides: dict[str, dict[Target, dict[str, str | None]]]
+```
+
+- `register_defaults()` and any bulk-loading of `discover_compat`
+  output write to `_base` via a new `register_base`/`register_many`
+  variant (internal use).
+- The public `register_compat()` / `CompatRegistry.register()`
+  (called by end users) always writes to `_overrides`.
+- Lookup methods (`get_config`, `is_unsupported`,
+  `get_min_and_max_versions`, `find_closest_version`,
+  `is_valid_version`) resolve against `_overrides` first (using the
+  specificity rule above); if no entry in `_overrides` matches, they
+  fall back to `_base`.
+- `exist_ok` conflict detection in `register()`/`register_many()`
+  only ever compares a new override against existing entries in
+  `_overrides` — never against `_base`. A user can therefore always
+  register a correction over a shipped/discovered default without
+  passing `exist_ok=True`, and re-running discovery to refresh
+  `_base` can never conflict with a stored user override.
+
+### Public API changes
+
+- `CompatRegistry.register(pkg_name, target: Target, pkg_version_min,
+  pkg_version_max, exist_ok=False)` — `python_version: str` param
+  replaced by `target: Target`.
+- `CompatRegistry.register_many(mapping: dict[str, dict[Target,
+  dict[str, str | None]]], exist_ok=False)`.
+- `CompatRegistry.get_config`, `is_unsupported`,
+  `get_min_and_max_versions`, `find_closest_version`,
+  `is_valid_version` — all take `target: Target` instead of
+  `python_version: str`.
+- Module-level `feu.compat.register_compat(mapping, exist_ok=False)`,
+  `find_closest_version(pkg_name, pkg_version, target)`,
+  `is_valid_version(pkg_name, pkg_version, target)` — same param
+  rename.
+- `DEFAULT_COMPAT` / `register_defaults` internally build `Target`
+  keys from the existing python-version-only data (each entry becomes
+  `Target(python_version=X)`).
+- `discover_compat` continues to return `dict[str, dict[str, str |
+  None]]` keyed by python-version string (unchanged, since it only
+  knows about the python-version axis); the caller (`register_defaults`
+  / `dev/discover_compat.py`) wraps each key in `Target(python_version=X)`
+  when loading it into the registry.
+
+### Callsite update
+
+`feu/install/utils.py::install_package_closest_version` changes:
+
+```python
+find_closest_version(
+    pkg_name=package.name,
+    pkg_version=pkg_version,
+    target=Target(python_version=get_python_major_minor()),
+)
+```
+
+No behavioral change — `os`/`arch`/`free_threaded` stay unspecified
+(wildcard / `False`), matching current behavior exactly.
+
+## Testing
+
+- Unit tests for `Target` (equality/hashability, defaults).
+- Unit tests for `CompatRegistry` specificity/wildcard matching:
+  exact match, os-only wildcard, arch-only wildcard, free-threaded
+  mismatch, most-specific-wins with multiple candidate matches.
+- Unit tests for override-vs-base precedence: override present →
+  wins; override absent → falls back to base; `exist_ok=False`
+  conflict only triggers between two overrides, not override vs base.
+- Update existing `test_registry.py`, `test_defaults.py`,
+  `test_interface.py`, `test_discovery.py` call sites to use `Target`.
+- Update `tests/integration/compat/test_discovery.py` if it touches
+  the registry-loading path.

--- a/src/feu/__main__.py
+++ b/src/feu/__main__.py
@@ -2,9 +2,7 @@ r"""Contain the main entry point."""
 
 from __future__ import annotations
 
-from feu.compat import find_closest_version as find_closest_version_
-from feu.compat import is_valid_version
-from feu.compat import Target
+from feu.compat import Target, find_closest_version as find_closest_version_, is_valid_version
 from feu.imports import check_click, is_click_available
 from feu.install import install_package_closest_version
 from feu.utils.installer import InstallerSpec
@@ -137,7 +135,9 @@ def check_valid_version(pkg_name: str, pkg_version: str, python_version: str) ->
         ```
     """
     print(  # noqa: T201
-        is_valid_version(pkg_name=pkg_name, pkg_version=pkg_version, target=Target(python_version=python_version))
+        is_valid_version(
+            pkg_name=pkg_name, pkg_version=pkg_version, target=Target(python_version=python_version)
+        )
     )
 
 

--- a/src/feu/__main__.py
+++ b/src/feu/__main__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from feu.compat import find_closest_version as find_closest_version_
 from feu.compat import is_valid_version
+from feu.compat import Target
 from feu.imports import check_click, is_click_available
 from feu.install import install_package_closest_version
 from feu.utils.installer import InstallerSpec
@@ -109,7 +110,7 @@ def find_closest_version(pkg_name: str, pkg_version: str, python_version: str) -
     """
     print(  # noqa: T201
         find_closest_version_(
-            pkg_name=pkg_name, pkg_version=pkg_version, python_version=python_version
+            pkg_name=pkg_name, pkg_version=pkg_version, target=Target(python_version=python_version)
         )
     )
 
@@ -136,7 +137,7 @@ def check_valid_version(pkg_name: str, pkg_version: str, python_version: str) ->
         ```
     """
     print(  # noqa: T201
-        is_valid_version(pkg_name=pkg_name, pkg_version=pkg_version, python_version=python_version)
+        is_valid_version(pkg_name=pkg_name, pkg_version=pkg_version, target=Target(python_version=python_version))
     )
 
 

--- a/src/feu/compat/__init__.py
+++ b/src/feu/compat/__init__.py
@@ -1,11 +1,12 @@
-r"""Contain a registry-based system for package/Python-version
-compatibility resolution."""
+r"""Contain a registry-based system for package/target compatibility
+resolution."""
 
 from __future__ import annotations
 
 __all__ = [
     "UNSUPPORTED",
     "CompatRegistry",
+    "Target",
     "UnsupportedVersionError",
     "discover_compat",
     "find_closest_version",
@@ -22,3 +23,4 @@ from feu.compat.interface import (
     register_compat,
 )
 from feu.compat.registry import UNSUPPORTED, CompatRegistry, UnsupportedVersionError
+from feu.compat.target import Target

--- a/src/feu/compat/defaults.py
+++ b/src/feu/compat/defaults.py
@@ -6,6 +6,8 @@ __all__ = ["DEFAULT_COMPAT", "register_defaults"]
 
 from typing import TYPE_CHECKING
 
+from feu.compat.target import Target
+
 if TYPE_CHECKING:
     from feu.compat.registry import CompatRegistry
 
@@ -141,10 +143,17 @@ DEFAULT_COMPAT: dict[str, dict[str, dict[str, str | None]]] = {
 
 
 def register_defaults(registry: CompatRegistry) -> None:
-    r"""Populate a registry with the default package compatibility
-    constraints.
+    r"""Populate a registry's base layer with the default package
+    compatibility constraints.
 
     Args:
         registry: The registry to populate.
     """
-    registry.register_many(DEFAULT_COMPAT)
+    mapping: dict[str, dict[Target, dict[str, str | None]]] = {
+        pkg_name: {
+            Target(python_version=python_version): config
+            for python_version, config in versions.items()
+        }
+        for pkg_name, versions in DEFAULT_COMPAT.items()
+    }
+    registry.register_many(mapping, layer="base")

--- a/src/feu/compat/interface.py
+++ b/src/feu/compat/interface.py
@@ -1,4 +1,4 @@
-r"""Define the public interface for package/Python-version compatibility
+r"""Define the public interface for package/target compatibility
 resolution."""
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ __all__ = [
 
 from feu.compat.defaults import register_defaults
 from feu.compat.registry import CompatRegistry
+from feu.compat.target import Target
 
 
 def get_default_registry() -> CompatRegistry:
@@ -19,7 +20,7 @@ def get_default_registry() -> CompatRegistry:
 
     The registry is created on the first call and reused on all
     subsequent calls (singleton pattern). It is pre-configured with
-    the default package version constraints.
+    the default package version constraints in its base layer.
 
     Returns:
         A singleton ``CompatRegistry`` configured with the default
@@ -27,9 +28,9 @@ def get_default_registry() -> CompatRegistry:
 
     Example:
         ```pycon
-        >>> from feu.compat import get_default_registry
+        >>> from feu.compat import get_default_registry, Target
         >>> registry = get_default_registry()
-        >>> registry.is_valid_version("numpy", "2.0.2", "3.11")
+        >>> registry.is_valid_version("numpy", "2.0.2", Target(python_version="3.11"))
         True
 
         ```
@@ -42,78 +43,88 @@ def get_default_registry() -> CompatRegistry:
 
 
 def register_compat(
-    mapping: dict[str, dict[str, dict[str, str | None]]],
+    mapping: dict[str, dict[Target, dict[str, str | None]]],
     exist_ok: bool = False,
 ) -> None:
     r"""Register custom package configurations into the default global
-    registry.
+    registry's override layer.
+
+    Override entries always take precedence over the default/base
+    layer, and are only conflict-checked against other overrides, so
+    correcting an inaccurate default never requires ``exist_ok=True``.
 
     Args:
-        mapping: Mapping of package name to Python version to
+        mapping: Mapping of package name to ``Target`` to
             ``{"min": ..., "max": ...}`` constraints.
         exist_ok: If ``False`` (default), raises an error if any entry
-            is already registered. If ``True``, overwrites existing
-            registrations silently.
+            is already registered as an override. If ``True``,
+            overwrites existing override registrations silently.
 
     Raises:
-        RuntimeError: If any entry is already registered and
-            ``exist_ok`` is ``False``.
+        RuntimeError: If any entry is already registered as an
+            override and ``exist_ok`` is ``False``.
 
     Example:
         ```pycon
-        >>> from feu.compat import register_compat
-        >>> register_compat({"my_package": {"3.11": {"min": "1.0.0", "max": None}}})
+        >>> from feu.compat import register_compat, Target
+        >>> register_compat(
+        ...     {"my_package": {Target(python_version="3.11"): {"min": "1.0.0", "max": None}}}
+        ... )
 
         ```
     """
     get_default_registry().register_many(mapping, exist_ok=exist_ok)
 
 
-def find_closest_version(pkg_name: str, pkg_version: str, python_version: str) -> str:
+def find_closest_version(pkg_name: str, pkg_version: str, target: Target) -> str:
     r"""Find the closest valid version for a package using the default
     registry.
 
     Args:
         pkg_name: The package name to check (e.g., ``"numpy"``).
         pkg_version: The requested package version.
-        python_version: The Python version (e.g., ``"3.11"``).
+        target: The compatibility target.
 
     Returns:
         The closest valid version as a string.
 
     Example:
         ```pycon
-        >>> from feu.compat import find_closest_version
-        >>> find_closest_version(pkg_name="numpy", pkg_version="2.0.2", python_version="3.11")
+        >>> from feu.compat import find_closest_version, Target
+        >>> find_closest_version(
+        ...     pkg_name="numpy", pkg_version="2.0.2", target=Target(python_version="3.11")
+        ... )
         '2.0.2'
 
         ```
     """
     return get_default_registry().find_closest_version(
-        pkg_name=pkg_name, pkg_version=pkg_version, python_version=python_version
+        pkg_name=pkg_name, pkg_version=pkg_version, target=target
     )
 
 
-def is_valid_version(pkg_name: str, pkg_version: str, python_version: str) -> bool:
-    r"""Check if a package version is valid for a Python version using
-    the default registry.
+def is_valid_version(pkg_name: str, pkg_version: str, target: Target) -> bool:
+    r"""Check if a package version is valid for a target using the
+    default registry.
 
     Args:
         pkg_name: The package name to check (e.g., ``"numpy"``).
         pkg_version: The package version to validate.
-        python_version: The Python version (e.g., ``"3.11"``).
+        target: The compatibility target.
 
     Returns:
         ``True`` if valid or unconfigured, ``False`` otherwise.
 
     Example:
         ```pycon
-        >>> from feu.compat import is_valid_version
-        >>> is_valid_version(pkg_name="numpy", pkg_version="2.0.2", python_version="3.11")
+        >>> from feu.compat import is_valid_version, Target
+        >>> is_valid_version(
+        ...     pkg_name="numpy", pkg_version="2.0.2", target=Target(python_version="3.11")
+        ... )
         True
 
         ```
     """
     return get_default_registry().is_valid_version(
-        pkg_name=pkg_name, pkg_version=pkg_version, python_version=python_version
+        pkg_name=pkg_name, pkg_version=pkg_version, target=target
     )

--- a/src/feu/compat/interface.py
+++ b/src/feu/compat/interface.py
@@ -10,9 +10,13 @@ __all__ = [
     "register_compat",
 ]
 
+from typing import TYPE_CHECKING
+
 from feu.compat.defaults import register_defaults
 from feu.compat.registry import CompatRegistry
-from feu.compat.target import Target
+
+if TYPE_CHECKING:
+    from feu.compat.target import Target
 
 
 def get_default_registry() -> CompatRegistry:

--- a/src/feu/compat/registry.py
+++ b/src/feu/compat/registry.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 __all__ = ["UNSUPPORTED", "CompatRegistry", "UnsupportedVersionError"]
 
 import copy
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from packaging.version import Version
 
-from feu.compat.target import Target
+if TYPE_CHECKING:
+    from feu.compat.target import Target
 
 UNSUPPORTED = "unsupported"
 r"""Sentinel used as the ``min``/``max`` value to mark a target for
@@ -112,6 +113,7 @@ class CompatRegistry:
         self,
         pkg_name: str,
         target: Target,
+        *,
         pkg_version_min: str | None,
         pkg_version_max: str | None,
         exist_ok: bool = False,

--- a/src/feu/compat/registry.py
+++ b/src/feu/compat/registry.py
@@ -1,8 +1,8 @@
 r"""Define the compatibility registry for package version resolution.
 
 This module provides a registry system that manages and resolves valid
-package version ranges per Python version, enabling lookup of the
-closest valid version and validation of a given version.
+package version ranges per compatibility target, enabling lookup of
+the closest valid version and validation of a given version.
 """
 
 from __future__ import annotations
@@ -10,194 +10,261 @@ from __future__ import annotations
 __all__ = ["UNSUPPORTED", "CompatRegistry", "UnsupportedVersionError"]
 
 import copy
+from typing import Literal
 
 from packaging.version import Version
 
+from feu.compat.target import Target
+
 UNSUPPORTED = "unsupported"
-r"""Sentinel used as the ``min``/``max`` value to mark a Python version
-for which no package version is valid.
+r"""Sentinel used as the ``min``/``max`` value to mark a target for
+which no package version is valid.
 
 This is distinct from ``None``, which means "unconstrained" (i.e. any
 version is valid).
 """
 
+_Layer = Literal["base", "override"]
+
 
 class UnsupportedVersionError(Exception):
-    r"""Raised when no package version is compatible with a given Python
-    version."""
+    r"""Raised when no package version is compatible with a given
+    target."""
 
 
 class CompatRegistry:
-    r"""Manage package version compatibility across different Python
-    versions.
+    r"""Manage package version compatibility across different
+    compatibility targets.
 
-    This registry maintains package version constraints indexed by
-    package name and Python version. Each entry specifies the minimum
-    and maximum compatible versions for a package on a specific Python
-    version.
+    The registry holds two independent layers per package:
 
-    The registry state is structured as a nested dictionary::
+    - ``base``: populated by ``register_defaults`` and discovered
+      data. Entries here can be freely refreshed (e.g. by re-running
+      discovery) without ever conflicting with user overrides.
+    - ``overrides``: populated by user calls (``register_compat`` /
+      ``register(layer="override")``, the default). Overrides always
+      take precedence over ``base`` and are only conflict-checked
+      against other overrides.
 
-        {
-            package_name: {
-                python_version: {
-                    "min": minimum_version_string or None,
-                    "max": maximum_version_string or None,
-                },
-                ...
-            },
-            ...
-        }
+    Each layer maps package name to ``Target`` to ``{"min": ...,
+    "max": ...}``. A lookup target matches a stored entry when
+    ``python_version`` and ``free_threaded`` are equal, and the
+    stored entry's ``os``/``arch`` are either ``None`` (wildcard) or
+    equal to the lookup target's ``os``/``arch``. Among all matching
+    entries in a layer, the most specific one (most non-``None``
+    ``os``/``arch`` fields) wins; ties are broken by most-recently
+    registered.
 
     Args:
-        initial_state: Optional initial mapping of package constraints.
-            If provided, the state is copied to prevent external
-            mutations.
+        initial_state: Optional initial mapping of package
+            constraints, seeding the ``base`` layer. If provided, the
+            state is copied to prevent external mutations.
 
     Example:
         ```pycon
-        >>> from feu.compat import CompatRegistry
+        >>> from feu.compat import CompatRegistry, Target
         >>> registry = CompatRegistry()
         >>> registry.register(
         ...     pkg_name="numpy",
-        ...     python_version="3.11",
+        ...     target=Target(python_version="3.11"),
         ...     pkg_version_min="1.23.2",
         ...     pkg_version_max="2.4.6",
+        ...     layer="base",
         ... )
-        >>> registry.is_valid_version("numpy", "2.0.2", "3.11")
+        >>> registry.is_valid_version("numpy", "2.0.2", Target(python_version="3.11"))
         True
 
         ```
     """
 
     def __init__(
-        self, initial_state: dict[str, dict[str, dict[str, str | None]]] | None = None
+        self, initial_state: dict[str, dict[Target, dict[str, str | None]]] | None = None
     ) -> None:
-        self.registry: dict[str, dict[str, dict[str, str | None]]] = copy.deepcopy(
+        self._base: dict[str, dict[Target, dict[str, str | None]]] = copy.deepcopy(
             initial_state or {}
         )
+        self._overrides: dict[str, dict[Target, dict[str, str | None]]] = {}
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__qualname__}(\n  (registry): {self.registry}\n)"
+        return (
+            f"{self.__class__.__qualname__}(\n"
+            f"  (base): {self._base}\n"
+            f"  (overrides): {self._overrides}\n)"
+        )
 
     def __str__(self) -> str:
-        return f"{self.__class__.__qualname__}(\n  (registry): {self.registry}\n)"
+        return self.__repr__()
+
+    @property
+    def base(self) -> dict[str, dict[Target, dict[str, str | None]]]:
+        r"""The base layer (defaults/discovered data)."""
+        return self._base
+
+    @property
+    def overrides(self) -> dict[str, dict[Target, dict[str, str | None]]]:
+        r"""The override layer (user-supplied corrections)."""
+        return self._overrides
+
+    def _layer_table(self, layer: _Layer) -> dict[str, dict[Target, dict[str, str | None]]]:
+        return self._base if layer == "base" else self._overrides
 
     def register(
         self,
         pkg_name: str,
-        python_version: str,
+        target: Target,
         pkg_version_min: str | None,
         pkg_version_max: str | None,
         exist_ok: bool = False,
+        layer: _Layer = "override",
     ) -> None:
-        r"""Register a package configuration for a Python version.
+        r"""Register a package configuration for a compatibility
+        target.
 
         Args:
             pkg_name: The package name to register (e.g., ``"numpy"``).
-            python_version: The Python version (e.g., ``"3.11"``).
-            pkg_version_min: The minimum valid package version for this
-                Python version, or ``None`` for no minimum.
-            pkg_version_max: The maximum valid package version for this
-                Python version, or ``None`` for no maximum.
+            target: The compatibility target.
+            pkg_version_min: The minimum valid package version for
+                this target, or ``None`` for no minimum.
+            pkg_version_max: The maximum valid package version for
+                this target, or ``None`` for no maximum.
             exist_ok: If ``False``, a ``RuntimeError`` is raised when a
                 configuration already exists for this package and
-                Python version. Set to ``True`` to overwrite.
+                target **within the same layer**. Set to ``True`` to
+                overwrite.
+            layer: Which layer to write to, ``"base"`` or
+                ``"override"``. Defaults to ``"override"``, matching
+                the public ``register_compat`` behavior.
 
         Raises:
             RuntimeError: If a configuration already exists for the
-                given package name and Python version, and
+                given package name and target in the same layer, and
                 ``exist_ok`` is ``False``.
         """
-        self.registry[pkg_name] = self.registry.get(pkg_name, {})
+        table = self._layer_table(layer)
+        table[pkg_name] = table.get(pkg_name, {})
 
-        if python_version in self.registry[pkg_name] and not exist_ok:
+        if target in table[pkg_name] and not exist_ok:
             msg = (
-                f"A package configuration ({self.registry[pkg_name][python_version]}) is "
-                f"already registered for package {pkg_name} and python {python_version}. "
-                f"Please use `exist_ok=True` if you want to overwrite the package config"
+                f"A package configuration ({table[pkg_name][target]}) is already "
+                f"registered for package {pkg_name} and target {target} in the "
+                f"'{layer}' layer. Please use `exist_ok=True` if you want to "
+                f"overwrite the package config"
             )
             raise RuntimeError(msg)
 
-        self.registry[pkg_name][python_version] = {
-            "min": pkg_version_min,
-            "max": pkg_version_max,
-        }
+        table[pkg_name][target] = {"min": pkg_version_min, "max": pkg_version_max}
 
     def register_many(
         self,
-        mapping: dict[str, dict[str, dict[str, str | None]]],
+        mapping: dict[str, dict[Target, dict[str, str | None]]],
         exist_ok: bool = False,
+        layer: _Layer = "override",
     ) -> None:
         r"""Register multiple package configurations at once.
 
         Args:
-            mapping: Mapping of package name to Python version to
+            mapping: Mapping of package name to ``Target`` to
                 ``{"min": ..., "max": ...}`` constraints.
-            exist_ok: If ``False``, a ``RuntimeError`` is raised when
-                any entry already exists. Set to ``True`` to overwrite.
+            exist_ok: Forwarded to ``register``.
+            layer: Forwarded to ``register``.
         """
-        for pkg_name, versions in mapping.items():
-            for python_version, config in versions.items():
+        for pkg_name, targets in mapping.items():
+            for target, config in targets.items():
                 self.register(
                     pkg_name=pkg_name,
-                    python_version=python_version,
+                    target=target,
                     pkg_version_min=config.get("min"),
                     pkg_version_max=config.get("max"),
                     exist_ok=exist_ok,
+                    layer=layer,
                 )
 
-    def get_config(self, pkg_name: str, python_version: str) -> dict[str, str | None]:
+    @staticmethod
+    def _matches(entry_target: Target, lookup: Target) -> bool:
+        if entry_target.python_version != lookup.python_version:
+            return False
+        if entry_target.free_threaded != lookup.free_threaded:
+            return False
+        if entry_target.os is not None and entry_target.os != lookup.os:
+            return False
+        return not (entry_target.arch is not None and entry_target.arch != lookup.arch)
+
+    @staticmethod
+    def _specificity(entry_target: Target) -> int:
+        return (entry_target.os is not None) + (entry_target.arch is not None)
+
+    def _resolve_in_layer(
+        self, table: dict[str, dict[Target, dict[str, str | None]]], pkg_name: str, target: Target
+    ) -> dict[str, str | None] | None:
+        if pkg_name not in table:
+            return None
+        best: dict[str, str | None] | None = None
+        best_specificity = -1
+        for entry_target, config in table[pkg_name].items():
+            if not self._matches(entry_target, target):
+                continue
+            specificity = self._specificity(entry_target)
+            if specificity >= best_specificity:
+                best_specificity = specificity
+                best = config
+        return best
+
+    def get_config(self, pkg_name: str, target: Target) -> dict[str, str | None]:
         r"""Get the package version configuration for a package and
-        Python version.
+        compatibility target.
+
+        Checks the override layer first, then falls back to the base
+        layer.
 
         Args:
             pkg_name: The package name to query (e.g., ``"numpy"``).
-            python_version: The Python version (e.g., ``"3.11"``).
+            target: The compatibility target.
 
         Returns:
-            A dictionary with ``"min"`` and ``"max"`` keys, or an empty
-            dictionary if no configuration exists.
+            A dictionary with ``"min"`` and ``"max"`` keys, or an
+            empty dictionary if no configuration matches.
         """
-        if pkg_name not in self.registry:
-            return {}
-        return self.registry[pkg_name].get(python_version, {})
+        config = self._resolve_in_layer(self._overrides, pkg_name, target)
+        if config is not None:
+            return config
+        return self._resolve_in_layer(self._base, pkg_name, target) or {}
 
-    def is_unsupported(self, pkg_name: str, python_version: str) -> bool:
-        r"""Indicate if no package version is valid for a Python version.
+    def is_unsupported(self, pkg_name: str, target: Target) -> bool:
+        r"""Indicate if no package version is valid for a target.
 
         Args:
             pkg_name: The package name to check (e.g., ``"numpy"``).
-            python_version: The Python version (e.g., ``"3.11"``).
+            target: The compatibility target.
 
         Returns:
-            ``True`` if the package has no valid version for the given
-            Python version, ``False`` otherwise.
+            ``True`` if the package has no valid version for the
+            given target, ``False`` otherwise.
         """
-        config = self.get_config(pkg_name=pkg_name, python_version=python_version)
+        config = self.get_config(pkg_name=pkg_name, target=target)
         return config.get("min") == UNSUPPORTED or config.get("max") == UNSUPPORTED
 
     def get_min_and_max_versions(
-        self, pkg_name: str, python_version: str
+        self, pkg_name: str, target: Target
     ) -> tuple[Version | None, Version | None]:
-        r"""Get the minimum and maximum versions as ``Version`` objects.
+        r"""Get the minimum and maximum versions as ``Version``
+        objects.
 
         Args:
             pkg_name: The package name to query (e.g., ``"numpy"``).
-            python_version: The Python version (e.g., ``"3.11"``).
+            target: The compatibility target.
 
         Returns:
             A tuple ``(min_version, max_version)``, either value being
             ``None`` if unconstrained or unconfigured.
 
         Raises:
-            UnsupportedVersionError: If no package version is valid for
-                the given Python version.
+            UnsupportedVersionError: If no package version is valid
+                for the given target.
         """
-        if self.is_unsupported(pkg_name=pkg_name, python_version=python_version):
-            msg = f"No version of package {pkg_name} is compatible with Python {python_version}"
+        if self.is_unsupported(pkg_name=pkg_name, target=target):
+            msg = f"No version of package {pkg_name} is compatible with target {target}"
             raise UnsupportedVersionError(msg)
-        config = self.get_config(pkg_name=pkg_name, python_version=python_version)
+        config = self.get_config(pkg_name=pkg_name, target=target)
         min_version = config.get("min", None)
         max_version = config.get("max", None)
         if min_version is not None:
@@ -206,50 +273,46 @@ class CompatRegistry:
             max_version = Version(max_version)
         return min_version, max_version
 
-    def find_closest_version(self, pkg_name: str, pkg_version: str, python_version: str) -> str:
+    def find_closest_version(self, pkg_name: str, pkg_version: str, target: Target) -> str:
         r"""Find the closest valid version for a package.
 
         Args:
             pkg_name: The package name to check (e.g., ``"numpy"``).
             pkg_version: The requested package version.
-            python_version: The Python version (e.g., ``"3.11"``).
+            target: The compatibility target.
 
         Returns:
             The closest valid version as a string.
 
         Raises:
-            UnsupportedVersionError: If no package version is valid for
-                the given Python version.
+            UnsupportedVersionError: If no package version is valid
+                for the given target.
         """
         version = Version(pkg_version)
-        min_version, max_version = self.get_min_and_max_versions(
-            pkg_name=pkg_name, python_version=python_version
-        )
+        min_version, max_version = self.get_min_and_max_versions(pkg_name=pkg_name, target=target)
         if min_version is not None and version < min_version:
             return min_version.base_version
         if max_version is not None and version > max_version:
             return max_version.base_version
         return pkg_version
 
-    def is_valid_version(self, pkg_name: str, pkg_version: str, python_version: str) -> bool:
-        r"""Check if a package version is valid for a Python version.
+    def is_valid_version(self, pkg_name: str, pkg_version: str, target: Target) -> bool:
+        r"""Check if a package version is valid for a target.
 
         Args:
             pkg_name: The package name to check (e.g., ``"numpy"``).
             pkg_version: The package version to validate.
-            python_version: The Python version (e.g., ``"3.11"``).
+            target: The compatibility target.
 
         Returns:
             ``True`` if valid or unconfigured, ``False`` otherwise,
             including when no package version is valid for the given
-            Python version.
+            target.
         """
-        if self.is_unsupported(pkg_name=pkg_name, python_version=python_version):
+        if self.is_unsupported(pkg_name=pkg_name, target=target):
             return False
         version = Version(pkg_version)
-        min_version, max_version = self.get_min_and_max_versions(
-            pkg_name=pkg_name, python_version=python_version
-        )
+        min_version, max_version = self.get_min_and_max_versions(pkg_name=pkg_name, target=target)
         return (min_version is None or min_version <= version) and (
             max_version is None or version <= max_version
         )

--- a/src/feu/compat/target.py
+++ b/src/feu/compat/target.py
@@ -1,0 +1,40 @@
+r"""Define the compatibility target key used to look up package
+version constraints."""
+
+from __future__ import annotations
+
+__all__ = ["Target"]
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Target:
+    r"""Identify the environment a package compatibility constraint
+    applies to.
+
+    Args:
+        python_version: The Python version, e.g. ``"3.11"``.
+        free_threaded: ``True`` for a free-threaded (no-GIL) Python
+            build, e.g. ``3.14t``. Defaults to ``False``.
+        os: The operating system, e.g. ``"linux"``, ``"macos"``,
+            ``"windows"``. ``None`` means "any OS" when used as a
+            registry entry, and "unspecified" when used as a lookup
+            target.
+        arch: The CPU architecture, e.g. ``"x86_64"``, ``"arm64"``.
+            ``None`` means "any architecture" when used as a registry
+            entry, and "unspecified" when used as a lookup target.
+
+    Example:
+        ```pycon
+        >>> from feu.compat.target import Target
+        >>> Target(python_version="3.14", free_threaded=True, os="linux", arch="x86_64")
+        Target(python_version='3.14', free_threaded=True, os='linux', arch='x86_64')
+
+        ```
+    """
+
+    python_version: str
+    free_threaded: bool = False
+    os: str | None = None
+    arch: str | None = None

--- a/src/feu/install/utils.py
+++ b/src/feu/install/utils.py
@@ -14,7 +14,7 @@ import shutil
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
-from feu.compat import find_closest_version
+from feu.compat import Target, find_closest_version
 from feu.install import InstallerRegistry
 from feu.version import get_python_major_minor
 
@@ -79,7 +79,7 @@ def install_package_closest_version(installer: InstallerSpec, package: PackageSp
             find_closest_version(
                 pkg_name=package.name,
                 pkg_version=pkg_version,
-                python_version=get_python_major_minor(),
+                target=Target(python_version=get_python_major_minor()),
             )
         ),
     )

--- a/tests/integration/install/pip/test_installer.py
+++ b/tests/integration/install/pip/test_installer.py
@@ -4,6 +4,7 @@ import pytest
 
 from feu import is_package_available
 from feu.compat import find_closest_version
+from feu.compat import Target
 from feu.install.pip import PipInstaller, PipxInstaller, UvInstaller
 from feu.testing import pip_available, pipx_available, uv_available
 from feu.utils.package import PackageSpec
@@ -20,7 +21,7 @@ def package() -> PackageSpec:
     return PackageSpec(
         name="mkdocs",
         version=find_closest_version(
-            pkg_name="mkdocs", pkg_version="1.6.1", python_version=get_python_major_minor()
+            pkg_name="mkdocs", pkg_version="1.6.1", target=Target(python_version=get_python_major_minor())
         ),
     )
 

--- a/tests/integration/install/pip/test_installer.py
+++ b/tests/integration/install/pip/test_installer.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import pytest
 
 from feu import is_package_available
-from feu.compat import find_closest_version
-from feu.compat import Target
+from feu.compat import Target, find_closest_version
 from feu.install.pip import PipInstaller, PipxInstaller, UvInstaller
 from feu.testing import pip_available, pipx_available, uv_available
 from feu.utils.package import PackageSpec
@@ -21,7 +20,9 @@ def package() -> PackageSpec:
     return PackageSpec(
         name="mkdocs",
         version=find_closest_version(
-            pkg_name="mkdocs", pkg_version="1.6.1", target=Target(python_version=get_python_major_minor())
+            pkg_name="mkdocs",
+            pkg_version="1.6.1",
+            target=Target(python_version=get_python_major_minor()),
         ),
     )
 

--- a/tests/integration/install/test_utils.py
+++ b/tests/integration/install/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 
 from feu import is_package_available
 from feu.compat import find_closest_version
+from feu.compat import Target
 from feu.install import (
     get_available_installers,
     install_package,
@@ -27,7 +28,7 @@ def pkg_name() -> str:
 @pytest.fixture(scope="module")
 def pkg_version(pkg_name: str) -> str:
     return find_closest_version(
-        pkg_name=pkg_name, pkg_version="1.6.1", python_version=get_python_major_minor()
+        pkg_name=pkg_name, pkg_version="1.6.1", target=Target(python_version=get_python_major_minor())
     )
 
 

--- a/tests/integration/install/test_utils.py
+++ b/tests/integration/install/test_utils.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import pytest
 
 from feu import is_package_available
-from feu.compat import find_closest_version
-from feu.compat import Target
+from feu.compat import Target, find_closest_version
 from feu.install import (
     get_available_installers,
     install_package,
@@ -28,7 +27,9 @@ def pkg_name() -> str:
 @pytest.fixture(scope="module")
 def pkg_version(pkg_name: str) -> str:
     return find_closest_version(
-        pkg_name=pkg_name, pkg_version="1.6.1", target=Target(python_version=get_python_major_minor())
+        pkg_name=pkg_name,
+        pkg_version="1.6.1",
+        target=Target(python_version=get_python_major_minor()),
     )
 
 

--- a/tests/unit/compat/test_defaults.py
+++ b/tests/unit/compat/test_defaults.py
@@ -2,22 +2,27 @@ from __future__ import annotations
 
 from feu.compat.defaults import DEFAULT_COMPAT, register_defaults
 from feu.compat.registry import CompatRegistry
+from feu.compat.target import Target
 
 #############################################
 #     Tests for register_defaults           #
 #############################################
 
 
-def test_register_defaults_populates_registry() -> None:
+def test_register_defaults_populates_base_layer() -> None:
     registry = CompatRegistry()
     register_defaults(registry)
-    assert registry.registry == DEFAULT_COMPAT
+    assert registry.overrides == {}
+    assert registry.base["numpy"][Target(python_version="3.11")] == {
+        "min": "1.23.2",
+        "max": "2.4.6",
+    }
 
 
 def test_register_defaults_numpy_entry() -> None:
     registry = CompatRegistry()
     register_defaults(registry)
-    assert registry.get_config(pkg_name="numpy", python_version="3.11") == {
+    assert registry.get_config(pkg_name="numpy", target=Target(python_version="3.11")) == {
         "min": "1.23.2",
         "max": "2.4.6",
     }

--- a/tests/unit/compat/test_interface.py
+++ b/tests/unit/compat/test_interface.py
@@ -11,6 +11,9 @@ from feu.compat.interface import (
     register_compat,
 )
 from feu.compat.registry import CompatRegistry
+from feu.compat.target import Target
+
+T311 = Target(python_version="3.11")
 
 ######################################
 #     Tests for get_default_registry #
@@ -19,7 +22,6 @@ from feu.compat.registry import CompatRegistry
 
 @pytest.fixture(autouse=True)
 def _reset_default_registry() -> None:
-    # Ensure each test starts from a fresh singleton.
     if hasattr(get_default_registry, "_registry"):
         del get_default_registry._registry
     yield
@@ -40,7 +42,7 @@ def test_get_default_registry_is_singleton() -> None:
 
 def test_get_default_registry_populated_with_defaults() -> None:
     registry = get_default_registry()
-    assert registry.get_config(pkg_name="numpy", python_version="3.11") == {
+    assert registry.get_config(pkg_name="numpy", target=T311) == {
         "min": "1.23.2",
         "max": "2.4.6",
     }
@@ -51,18 +53,29 @@ def test_get_default_registry_populated_with_defaults() -> None:
 #################################
 
 
-def test_register_compat_adds_to_default_registry() -> None:
-    register_compat({"my_package": {"3.11": {"min": "1.0.0", "max": None}}})
-    assert get_default_registry().get_config(pkg_name="my_package", python_version="3.11") == {
+def test_register_compat_adds_to_override_layer() -> None:
+    register_compat({"my_package": {T311: {"min": "1.0.0", "max": None}}})
+    registry = get_default_registry()
+    assert registry.get_config(pkg_name="my_package", target=T311) == {
         "min": "1.0.0",
         "max": None,
     }
+    assert registry.overrides == {"my_package": {T311: {"min": "1.0.0", "max": None}}}
 
 
 def test_register_compat_exist_ok_false_raises() -> None:
-    register_compat({"my_package": {"3.11": {"min": "1.0.0", "max": None}}})
+    register_compat({"my_package": {T311: {"min": "1.0.0", "max": None}}})
     with pytest.raises(RuntimeError, match=r"A package configuration .* is already registered"):
-        register_compat({"my_package": {"3.11": {"min": "2.0.0", "max": None}}})
+        register_compat({"my_package": {T311: {"min": "2.0.0", "max": None}}})
+
+
+def test_register_compat_overrides_a_default_without_exist_ok() -> None:
+    # numpy has a base entry for 3.11; overriding it must not require exist_ok=True.
+    register_compat({"numpy": {T311: {"min": "9.9.9", "max": None}}})
+    assert get_default_registry().get_config(pkg_name="numpy", target=T311) == {
+        "min": "9.9.9",
+        "max": None,
+    }
 
 
 ########################################
@@ -72,16 +85,13 @@ def test_register_compat_exist_ok_false_raises() -> None:
 
 def test_find_closest_version_delegates_to_default_registry() -> None:
     with patch.object(CompatRegistry, "find_closest_version", return_value="1.2.3") as mock_find:
-        result = find_closest_version(pkg_name="numpy", pkg_version="2.0.2", python_version="3.11")
+        result = find_closest_version(pkg_name="numpy", pkg_version="2.0.2", target=T311)
     assert result == "1.2.3"
-    mock_find.assert_called_once_with(pkg_name="numpy", pkg_version="2.0.2", python_version="3.11")
+    mock_find.assert_called_once_with(pkg_name="numpy", pkg_version="2.0.2", target=T311)
 
 
 def test_find_closest_version_uses_defaults() -> None:
-    assert (
-        find_closest_version(pkg_name="numpy", pkg_version="0.1.0", python_version="3.11")
-        == "1.23.2"
-    )
+    assert find_closest_version(pkg_name="numpy", pkg_version="0.1.0", target=T311) == "1.23.2"
 
 
 ##################################
@@ -91,10 +101,10 @@ def test_find_closest_version_uses_defaults() -> None:
 
 def test_is_valid_version_delegates_to_default_registry() -> None:
     with patch.object(CompatRegistry, "is_valid_version", return_value=False) as mock_valid:
-        result = is_valid_version(pkg_name="numpy", pkg_version="2.0.2", python_version="3.11")
+        result = is_valid_version(pkg_name="numpy", pkg_version="2.0.2", target=T311)
     assert result is False
-    mock_valid.assert_called_once_with(pkg_name="numpy", pkg_version="2.0.2", python_version="3.11")
+    mock_valid.assert_called_once_with(pkg_name="numpy", pkg_version="2.0.2", target=T311)
 
 
 def test_is_valid_version_uses_defaults() -> None:
-    assert not is_valid_version(pkg_name="numpy", pkg_version="0.1.0", python_version="3.11")
+    assert not is_valid_version(pkg_name="numpy", pkg_version="0.1.0", target=T311)

--- a/tests/unit/compat/test_registry.py
+++ b/tests/unit/compat/test_registry.py
@@ -30,7 +30,7 @@ def test_compat_registry_init_with_state() -> None:
 def test_compat_registry_init_copies_state() -> None:
     state = {"numpy": {T311: {"min": "1.0.0", "max": None}}}
     registry = CompatRegistry(state)
-    registry.register("torch", T311, "2.0.0", None, layer="base")
+    registry.register("torch", T311, pkg_version_min="2.0.0", pkg_version_max=None, layer="base")
     assert "torch" not in state
 
 
@@ -46,22 +46,22 @@ def test_compat_registry_str() -> None:
 
 def test_compat_registry_register_default_layer_is_override() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.0.2")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2")
     assert registry.overrides == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
     assert registry.base == {}
 
 
 def test_compat_registry_register_base_layer() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base")
     assert registry.base == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
     assert registry.overrides == {}
 
 
 def test_compat_registry_register_multiple() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
-    registry.register("my_package", T310, "1.1.0", "1.5.2", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base")
+    registry.register("my_package", T310, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base")
     assert registry.base == {
         "my_package": {
             T311: {"min": "1.2.0", "max": "2.0.2"},
@@ -72,26 +72,26 @@ def test_compat_registry_register_multiple() -> None:
 
 def test_compat_registry_register_exist_ok_false_same_layer() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base")
     with pytest.raises(
         RuntimeError, match=r"A package configuration .* is already registered for package"
     ):
-        registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
+        registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base")
 
 
 def test_compat_registry_register_override_never_conflicts_with_base() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base")
     # No exist_ok needed: override layer is independent of base layer.
-    registry.register("my_package", T311, "9.0.0", None)
+    registry.register("my_package", T311, pkg_version_min="9.0.0", pkg_version_max=None)
     assert registry.overrides == {"my_package": {T311: {"min": "9.0.0", "max": None}}}
     assert registry.base == {"my_package": {T311: {"min": "1.1.0", "max": "1.5.2"}}}
 
 
 def test_compat_registry_register_exist_ok_true() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
-    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base", exist_ok=True)
+    registry.register("my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base", exist_ok=True)
     assert registry.base == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
 
 
@@ -130,8 +130,8 @@ def test_compat_registry_register_many_exist_ok_true() -> None:
 
 def test_compat_registry_get_config_override_wins_over_base() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.0.0", None, layer="base")
-    registry.register("my_package", T311, "2.0.0", None, layer="override")
+    registry.register("my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
+    registry.register("my_package", T311, pkg_version_min="2.0.0", pkg_version_max=None, layer="override")
     assert registry.get_config(pkg_name="my_package", target=T311) == {
         "min": "2.0.0",
         "max": None,
@@ -140,7 +140,7 @@ def test_compat_registry_get_config_override_wins_over_base() -> None:
 
 def test_compat_registry_get_config_falls_back_to_base() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
     assert registry.get_config(pkg_name="my_package", target=T311) == {
         "min": "1.0.0",
         "max": None,
@@ -154,7 +154,7 @@ def test_compat_registry_get_config_empty_registry() -> None:
 
 def test_compat_registry_get_config_no_matching_target() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T310, "1.0.0", None, layer="base")
+    registry.register("my_package", T310, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
     assert registry.get_config(pkg_name="my_package", target=T311) == {}
 
 
@@ -165,7 +165,7 @@ def test_compat_registry_get_config_no_matching_target() -> None:
 
 def test_compat_registry_os_wildcard_matches_any_os() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
     linux_target = Target(python_version="3.11", os="linux")
     assert registry.get_config(pkg_name="my_package", target=linux_target) == {
         "min": "1.0.0",
@@ -175,12 +175,12 @@ def test_compat_registry_os_wildcard_matches_any_os() -> None:
 
 def test_compat_registry_more_specific_entry_wins() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
     registry.register(
         "my_package",
         Target(python_version="3.11", os="macos", arch="arm64"),
-        "5.0.0",
-        None,
+        pkg_version_min="5.0.0",
+        pkg_version_max=None,
         layer="base",
     )
     macos_arm = Target(python_version="3.11", os="macos", arch="arm64")
@@ -198,7 +198,7 @@ def test_compat_registry_more_specific_entry_wins() -> None:
 def test_compat_registry_free_threaded_must_match_exactly() -> None:
     registry = CompatRegistry()
     registry.register(
-        "my_package", Target(python_version="3.14", free_threaded=True), "1.0.0", None,
+        "my_package", Target(python_version="3.14", free_threaded=True), pkg_version_min="1.0.0", pkg_version_max=None,
         layer="base",
     )
     non_free_threaded = Target(python_version="3.14", free_threaded=False)
@@ -208,10 +208,10 @@ def test_compat_registry_free_threaded_must_match_exactly() -> None:
 def test_compat_registry_most_recent_wins_among_ties() -> None:
     registry = CompatRegistry()
     registry.register(
-        "my_package", Target(python_version="3.11", os="linux"), "1.0.0", None, layer="base"
+        "my_package", Target(python_version="3.11", os="linux"), pkg_version_min="1.0.0", pkg_version_max=None, layer="base"
     )
     registry.register(
-        "my_package", Target(python_version="3.11", arch="x86_64"), "2.0.0", None, layer="base"
+        "my_package", Target(python_version="3.11", arch="x86_64"), pkg_version_min="2.0.0", pkg_version_max=None, layer="base"
     )
     target = Target(python_version="3.11", os="linux", arch="x86_64")
     # Both entries match with equal specificity (one non-None field each);
@@ -229,7 +229,7 @@ def test_compat_registry_most_recent_wins_among_ties() -> None:
 
 def test_compat_registry_get_min_and_max_versions() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
     assert registry.get_min_and_max_versions(pkg_name="my_package", target=T311) == (
         Version("1.2.0"),
         Version("2.2.0"),
@@ -243,7 +243,7 @@ def test_compat_registry_get_min_and_max_versions_empty() -> None:
 
 def test_compat_registry_find_closest_version_valid() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
     assert (
         registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
         == "2.0.0"
@@ -260,7 +260,7 @@ def test_compat_registry_find_closest_version_missing() -> None:
 
 def test_compat_registry_find_closest_version_lower() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
     assert (
         registry.find_closest_version(pkg_name="my_package", pkg_version="1.0.0", target=T311)
         == "1.2.0"
@@ -269,7 +269,7 @@ def test_compat_registry_find_closest_version_lower() -> None:
 
 def test_compat_registry_find_closest_version_higher() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
     assert (
         registry.find_closest_version(pkg_name="my_package", pkg_version="3.0.0", target=T311)
         == "2.2.0"
@@ -278,19 +278,19 @@ def test_compat_registry_find_closest_version_higher() -> None:
 
 def test_compat_registry_is_valid_version_true() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
     assert registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
 
 
 def test_compat_registry_is_valid_version_false_min() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
     assert not registry.is_valid_version(pkg_name="my_package", pkg_version="1.0.0", target=T311)
 
 
 def test_compat_registry_is_valid_version_false_max() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
     assert not registry.is_valid_version(pkg_name="my_package", pkg_version="3.0.0", target=T311)
 
 
@@ -306,13 +306,13 @@ def test_compat_registry_is_valid_version_empty() -> None:
 
 def test_compat_registry_is_unsupported_true() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    registry.register("my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base")
     assert registry.is_unsupported(pkg_name="my_package", target=T315)
 
 
 def test_compat_registry_is_unsupported_false() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
     assert not registry.is_unsupported(pkg_name="my_package", target=T311)
 
 
@@ -323,19 +323,19 @@ def test_compat_registry_is_unsupported_unconfigured() -> None:
 
 def test_compat_registry_get_min_and_max_versions_unsupported_raises() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    registry.register("my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base")
     with pytest.raises(UnsupportedVersionError, match=r"No version of package my_package"):
         registry.get_min_and_max_versions(pkg_name="my_package", target=T315)
 
 
 def test_compat_registry_find_closest_version_unsupported_raises() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    registry.register("my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base")
     with pytest.raises(UnsupportedVersionError, match=r"No version of package my_package"):
         registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T315)
 
 
 def test_compat_registry_is_valid_version_unsupported_false() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    registry.register("my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base")
     assert not registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T315)

--- a/tests/unit/compat/test_registry.py
+++ b/tests/unit/compat/test_registry.py
@@ -53,15 +53,21 @@ def test_compat_registry_register_default_layer_is_override() -> None:
 
 def test_compat_registry_register_base_layer() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base"
+    )
     assert registry.base == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
     assert registry.overrides == {}
 
 
 def test_compat_registry_register_multiple() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base")
-    registry.register("my_package", T310, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base"
+    )
+    registry.register(
+        "my_package", T310, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base"
+    )
     assert registry.base == {
         "my_package": {
             T311: {"min": "1.2.0", "max": "2.0.2"},
@@ -72,16 +78,22 @@ def test_compat_registry_register_multiple() -> None:
 
 def test_compat_registry_register_exist_ok_false_same_layer() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base"
+    )
     with pytest.raises(
         RuntimeError, match=r"A package configuration .* is already registered for package"
     ):
-        registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base")
+        registry.register(
+            "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base"
+        )
 
 
 def test_compat_registry_register_override_never_conflicts_with_base() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base"
+    )
     # No exist_ok needed: override layer is independent of base layer.
     registry.register("my_package", T311, pkg_version_min="9.0.0", pkg_version_max=None)
     assert registry.overrides == {"my_package": {T311: {"min": "9.0.0", "max": None}}}
@@ -90,8 +102,17 @@ def test_compat_registry_register_override_never_conflicts_with_base() -> None:
 
 def test_compat_registry_register_exist_ok_true() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base")
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.0.2", layer="base", exist_ok=True)
+    registry.register(
+        "my_package", T311, pkg_version_min="1.1.0", pkg_version_max="1.5.2", layer="base"
+    )
+    registry.register(
+        "my_package",
+        T311,
+        pkg_version_min="1.2.0",
+        pkg_version_max="2.0.2",
+        layer="base",
+        exist_ok=True,
+    )
     assert registry.base == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
 
 
@@ -130,8 +151,12 @@ def test_compat_registry_register_many_exist_ok_true() -> None:
 
 def test_compat_registry_get_config_override_wins_over_base() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
-    registry.register("my_package", T311, pkg_version_min="2.0.0", pkg_version_max=None, layer="override")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base"
+    )
+    registry.register(
+        "my_package", T311, pkg_version_min="2.0.0", pkg_version_max=None, layer="override"
+    )
     assert registry.get_config(pkg_name="my_package", target=T311) == {
         "min": "2.0.0",
         "max": None,
@@ -140,7 +165,9 @@ def test_compat_registry_get_config_override_wins_over_base() -> None:
 
 def test_compat_registry_get_config_falls_back_to_base() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base"
+    )
     assert registry.get_config(pkg_name="my_package", target=T311) == {
         "min": "1.0.0",
         "max": None,
@@ -154,7 +181,9 @@ def test_compat_registry_get_config_empty_registry() -> None:
 
 def test_compat_registry_get_config_no_matching_target() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T310, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
+    registry.register(
+        "my_package", T310, pkg_version_min="1.0.0", pkg_version_max=None, layer="base"
+    )
     assert registry.get_config(pkg_name="my_package", target=T311) == {}
 
 
@@ -165,7 +194,9 @@ def test_compat_registry_get_config_no_matching_target() -> None:
 
 def test_compat_registry_os_wildcard_matches_any_os() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base"
+    )
     linux_target = Target(python_version="3.11", os="linux")
     assert registry.get_config(pkg_name="my_package", target=linux_target) == {
         "min": "1.0.0",
@@ -175,7 +206,9 @@ def test_compat_registry_os_wildcard_matches_any_os() -> None:
 
 def test_compat_registry_more_specific_entry_wins() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.0.0", pkg_version_max=None, layer="base"
+    )
     registry.register(
         "my_package",
         Target(python_version="3.11", os="macos", arch="arm64"),
@@ -198,7 +231,10 @@ def test_compat_registry_more_specific_entry_wins() -> None:
 def test_compat_registry_free_threaded_must_match_exactly() -> None:
     registry = CompatRegistry()
     registry.register(
-        "my_package", Target(python_version="3.14", free_threaded=True), pkg_version_min="1.0.0", pkg_version_max=None,
+        "my_package",
+        Target(python_version="3.14", free_threaded=True),
+        pkg_version_min="1.0.0",
+        pkg_version_max=None,
         layer="base",
     )
     non_free_threaded = Target(python_version="3.14", free_threaded=False)
@@ -208,10 +244,18 @@ def test_compat_registry_free_threaded_must_match_exactly() -> None:
 def test_compat_registry_most_recent_wins_among_ties() -> None:
     registry = CompatRegistry()
     registry.register(
-        "my_package", Target(python_version="3.11", os="linux"), pkg_version_min="1.0.0", pkg_version_max=None, layer="base"
+        "my_package",
+        Target(python_version="3.11", os="linux"),
+        pkg_version_min="1.0.0",
+        pkg_version_max=None,
+        layer="base",
     )
     registry.register(
-        "my_package", Target(python_version="3.11", arch="x86_64"), pkg_version_min="2.0.0", pkg_version_max=None, layer="base"
+        "my_package",
+        Target(python_version="3.11", arch="x86_64"),
+        pkg_version_min="2.0.0",
+        pkg_version_max=None,
+        layer="base",
     )
     target = Target(python_version="3.11", os="linux", arch="x86_64")
     # Both entries match with equal specificity (one non-None field each);
@@ -229,7 +273,9 @@ def test_compat_registry_most_recent_wins_among_ties() -> None:
 
 def test_compat_registry_get_min_and_max_versions() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base"
+    )
     assert registry.get_min_and_max_versions(pkg_name="my_package", target=T311) == (
         Version("1.2.0"),
         Version("2.2.0"),
@@ -243,7 +289,9 @@ def test_compat_registry_get_min_and_max_versions_empty() -> None:
 
 def test_compat_registry_find_closest_version_valid() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base"
+    )
     assert (
         registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
         == "2.0.0"
@@ -260,7 +308,9 @@ def test_compat_registry_find_closest_version_missing() -> None:
 
 def test_compat_registry_find_closest_version_lower() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base"
+    )
     assert (
         registry.find_closest_version(pkg_name="my_package", pkg_version="1.0.0", target=T311)
         == "1.2.0"
@@ -269,7 +319,9 @@ def test_compat_registry_find_closest_version_lower() -> None:
 
 def test_compat_registry_find_closest_version_higher() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base"
+    )
     assert (
         registry.find_closest_version(pkg_name="my_package", pkg_version="3.0.0", target=T311)
         == "2.2.0"
@@ -278,19 +330,25 @@ def test_compat_registry_find_closest_version_higher() -> None:
 
 def test_compat_registry_is_valid_version_true() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base"
+    )
     assert registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
 
 
 def test_compat_registry_is_valid_version_false_min() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base"
+    )
     assert not registry.is_valid_version(pkg_name="my_package", pkg_version="1.0.0", target=T311)
 
 
 def test_compat_registry_is_valid_version_false_max() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base"
+    )
     assert not registry.is_valid_version(pkg_name="my_package", pkg_version="3.0.0", target=T311)
 
 
@@ -306,13 +364,17 @@ def test_compat_registry_is_valid_version_empty() -> None:
 
 def test_compat_registry_is_unsupported_true() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base")
+    registry.register(
+        "my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base"
+    )
     assert registry.is_unsupported(pkg_name="my_package", target=T315)
 
 
 def test_compat_registry_is_unsupported_false() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base")
+    registry.register(
+        "my_package", T311, pkg_version_min="1.2.0", pkg_version_max="2.2.0", layer="base"
+    )
     assert not registry.is_unsupported(pkg_name="my_package", target=T311)
 
 
@@ -323,19 +385,25 @@ def test_compat_registry_is_unsupported_unconfigured() -> None:
 
 def test_compat_registry_get_min_and_max_versions_unsupported_raises() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base")
+    registry.register(
+        "my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base"
+    )
     with pytest.raises(UnsupportedVersionError, match=r"No version of package my_package"):
         registry.get_min_and_max_versions(pkg_name="my_package", target=T315)
 
 
 def test_compat_registry_find_closest_version_unsupported_raises() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base")
+    registry.register(
+        "my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base"
+    )
     with pytest.raises(UnsupportedVersionError, match=r"No version of package my_package"):
         registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T315)
 
 
 def test_compat_registry_is_valid_version_unsupported_false() -> None:
     registry = CompatRegistry()
-    registry.register("my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base")
+    registry.register(
+        "my_package", T315, pkg_version_min=UNSUPPORTED, pkg_version_max=UNSUPPORTED, layer="base"
+    )
     assert not registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T315)

--- a/tests/unit/compat/test_registry.py
+++ b/tests/unit/compat/test_registry.py
@@ -4,26 +4,33 @@ import pytest
 from packaging.version import Version
 
 from feu.compat.registry import UNSUPPORTED, CompatRegistry, UnsupportedVersionError
+from feu.compat.target import Target
+
+T311 = Target(python_version="3.11")
+T310 = Target(python_version="3.10")
+T315 = Target(python_version="3.15")
 
 ##################################
-#     Tests for CompatRegistry     #
+#     Tests for CompatRegistry    #
 ##################################
 
 
 def test_compat_registry_init_empty() -> None:
     registry = CompatRegistry()
-    assert registry.registry == {}
+    assert registry.base == {}
+    assert registry.overrides == {}
 
 
 def test_compat_registry_init_with_state() -> None:
-    registry = CompatRegistry({"numpy": {"3.11": {"min": "1.0.0", "max": None}}})
-    assert registry.registry == {"numpy": {"3.11": {"min": "1.0.0", "max": None}}}
+    registry = CompatRegistry({"numpy": {T311: {"min": "1.0.0", "max": None}}})
+    assert registry.base == {"numpy": {T311: {"min": "1.0.0", "max": None}}}
+    assert registry.overrides == {}
 
 
 def test_compat_registry_init_copies_state() -> None:
-    state = {"numpy": {"3.11": {"min": "1.0.0", "max": None}}}
+    state = {"numpy": {T311: {"min": "1.0.0", "max": None}}}
     registry = CompatRegistry(state)
-    registry.register("torch", "3.11", "2.0.0", None)
+    registry.register("torch", T311, "2.0.0", None, layer="base")
     assert "torch" not in state
 
 
@@ -37,153 +44,208 @@ def test_compat_registry_str() -> None:
     assert str(registry).startswith("CompatRegistry(")
 
 
-def test_compat_registry_register() -> None:
+def test_compat_registry_register_default_layer_is_override() -> None:
     registry = CompatRegistry()
-    registry.register(
-        pkg_name="my_package",
-        python_version="3.11",
-        pkg_version_min="1.2.0",
-        pkg_version_max="2.0.2",
-    )
-    assert registry.registry == {"my_package": {"3.11": {"min": "1.2.0", "max": "2.0.2"}}}
+    registry.register("my_package", T311, "1.2.0", "2.0.2")
+    assert registry.overrides == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
+    assert registry.base == {}
+
+
+def test_compat_registry_register_base_layer() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
+    assert registry.base == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
+    assert registry.overrides == {}
 
 
 def test_compat_registry_register_multiple() -> None:
     registry = CompatRegistry()
-    registry.register(
-        pkg_name="my_package",
-        python_version="3.11",
-        pkg_version_min="1.2.0",
-        pkg_version_max="2.0.2",
-    )
-    registry.register(
-        pkg_name="my_package",
-        python_version="3.10",
-        pkg_version_min="1.1.0",
-        pkg_version_max="1.5.2",
-    )
-    assert registry.registry == {
+    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
+    registry.register("my_package", T310, "1.1.0", "1.5.2", layer="base")
+    assert registry.base == {
         "my_package": {
-            "3.10": {"min": "1.1.0", "max": "1.5.2"},
-            "3.11": {"min": "1.2.0", "max": "2.0.2"},
+            T311: {"min": "1.2.0", "max": "2.0.2"},
+            T310: {"min": "1.1.0", "max": "1.5.2"},
         }
     }
 
 
-def test_compat_registry_register_exist_ok_false() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.1.0", "max": "1.5.2"}}})
+def test_compat_registry_register_exist_ok_false_same_layer() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
     with pytest.raises(
         RuntimeError, match=r"A package configuration .* is already registered for package"
     ):
-        registry.register(
-            pkg_name="my_package",
-            python_version="3.11",
-            pkg_version_min="1.2.0",
-            pkg_version_max="2.0.2",
-        )
+        registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base")
+
+
+def test_compat_registry_register_override_never_conflicts_with_base() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
+    # No exist_ok needed: override layer is independent of base layer.
+    registry.register("my_package", T311, "9.0.0", None)
+    assert registry.overrides == {"my_package": {T311: {"min": "9.0.0", "max": None}}}
+    assert registry.base == {"my_package": {T311: {"min": "1.1.0", "max": "1.5.2"}}}
 
 
 def test_compat_registry_register_exist_ok_true() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.1.0", "max": "1.5.2"}}})
-    registry.register(
-        pkg_name="my_package",
-        python_version="3.11",
-        pkg_version_min="1.2.0",
-        pkg_version_max="2.0.2",
-        exist_ok=True,
-    )
-    assert registry.registry == {"my_package": {"3.11": {"min": "1.2.0", "max": "2.0.2"}}}
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.1.0", "1.5.2", layer="base")
+    registry.register("my_package", T311, "1.2.0", "2.0.2", layer="base", exist_ok=True)
+    assert registry.base == {"my_package": {T311: {"min": "1.2.0", "max": "2.0.2"}}}
 
 
 def test_compat_registry_register_many() -> None:
     registry = CompatRegistry()
     registry.register_many(
         {
-            "numpy": {"3.11": {"min": "1.23.2", "max": "2.4.6"}},
-            "torch": {"3.11": {"min": "2.0.0", "max": None}},
-        }
+            "numpy": {T311: {"min": "1.23.2", "max": "2.4.6"}},
+            "torch": {T311: {"min": "2.0.0", "max": None}},
+        },
+        layer="base",
     )
-    assert registry.registry == {
-        "numpy": {"3.11": {"min": "1.23.2", "max": "2.4.6"}},
-        "torch": {"3.11": {"min": "2.0.0", "max": None}},
+    assert registry.base == {
+        "numpy": {T311: {"min": "1.23.2", "max": "2.4.6"}},
+        "torch": {T311: {"min": "2.0.0", "max": None}},
     }
 
 
 def test_compat_registry_register_many_exist_ok_false() -> None:
-    registry = CompatRegistry({"numpy": {"3.11": {"min": "1.0.0", "max": None}}})
+    registry = CompatRegistry()
+    registry.register_many({"numpy": {T311: {"min": "1.0.0", "max": None}}}, layer="base")
     with pytest.raises(
         RuntimeError, match=r"A package configuration .* is already registered for package"
     ):
-        registry.register_many({"numpy": {"3.11": {"min": "2.0.0", "max": None}}})
+        registry.register_many({"numpy": {T311: {"min": "2.0.0", "max": None}}}, layer="base")
 
 
 def test_compat_registry_register_many_exist_ok_true() -> None:
-    registry = CompatRegistry({"numpy": {"3.11": {"min": "1.0.0", "max": None}}})
-    registry.register_many({"numpy": {"3.11": {"min": "2.0.0", "max": None}}}, exist_ok=True)
-    assert registry.registry == {"numpy": {"3.11": {"min": "2.0.0", "max": None}}}
+    registry = CompatRegistry()
+    registry.register_many({"numpy": {T311: {"min": "1.0.0", "max": None}}}, layer="base")
+    registry.register_many(
+        {"numpy": {T311: {"min": "2.0.0", "max": None}}}, layer="base", exist_ok=True
+    )
+    assert registry.base == {"numpy": {T311: {"min": "2.0.0", "max": None}}}
 
 
-def test_compat_registry_get_config() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.0.2"}}})
-    assert registry.get_config(pkg_name="my_package", python_version="3.11") == {
-        "min": "1.2.0",
-        "max": "2.0.2",
+def test_compat_registry_get_config_override_wins_over_base() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    registry.register("my_package", T311, "2.0.0", None, layer="override")
+    assert registry.get_config(pkg_name="my_package", target=T311) == {
+        "min": "2.0.0",
+        "max": None,
+    }
+
+
+def test_compat_registry_get_config_falls_back_to_base() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    assert registry.get_config(pkg_name="my_package", target=T311) == {
+        "min": "1.0.0",
+        "max": None,
     }
 
 
 def test_compat_registry_get_config_empty_registry() -> None:
     registry = CompatRegistry()
-    assert registry.get_config(pkg_name="my_package", python_version="3.11") == {}
+    assert registry.get_config(pkg_name="my_package", target=T311) == {}
 
 
-def test_compat_registry_get_config_empty_pkg_name() -> None:
-    registry = CompatRegistry({"my_package": {}})
-    assert registry.get_config(pkg_name="my_package", python_version="3.11") == {}
+def test_compat_registry_get_config_no_matching_target() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T310, "1.0.0", None, layer="base")
+    assert registry.get_config(pkg_name="my_package", target=T311) == {}
 
 
-def test_compat_registry_get_config_empty_python_version() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {}}})
-    assert registry.get_config(pkg_name="my_package", python_version="3.11") == {}
+#############################################
+#     Tests for wildcard/specificity match   #
+#############################################
+
+
+def test_compat_registry_os_wildcard_matches_any_os() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    linux_target = Target(python_version="3.11", os="linux")
+    assert registry.get_config(pkg_name="my_package", target=linux_target) == {
+        "min": "1.0.0",
+        "max": None,
+    }
+
+
+def test_compat_registry_more_specific_entry_wins() -> None:
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.0.0", None, layer="base")
+    registry.register(
+        "my_package",
+        Target(python_version="3.11", os="macos", arch="arm64"),
+        "5.0.0",
+        None,
+        layer="base",
+    )
+    macos_arm = Target(python_version="3.11", os="macos", arch="arm64")
+    linux = Target(python_version="3.11", os="linux")
+    assert registry.get_config(pkg_name="my_package", target=macos_arm) == {
+        "min": "5.0.0",
+        "max": None,
+    }
+    assert registry.get_config(pkg_name="my_package", target=linux) == {
+        "min": "1.0.0",
+        "max": None,
+    }
+
+
+def test_compat_registry_free_threaded_must_match_exactly() -> None:
+    registry = CompatRegistry()
+    registry.register(
+        "my_package", Target(python_version="3.14", free_threaded=True), "1.0.0", None,
+        layer="base",
+    )
+    non_free_threaded = Target(python_version="3.14", free_threaded=False)
+    assert registry.get_config(pkg_name="my_package", target=non_free_threaded) == {}
+
+
+def test_compat_registry_most_recent_wins_among_ties() -> None:
+    registry = CompatRegistry()
+    registry.register(
+        "my_package", Target(python_version="3.11", os="linux"), "1.0.0", None, layer="base"
+    )
+    registry.register(
+        "my_package", Target(python_version="3.11", arch="x86_64"), "2.0.0", None, layer="base"
+    )
+    target = Target(python_version="3.11", os="linux", arch="x86_64")
+    # Both entries match with equal specificity (one non-None field each);
+    # the most recently registered one wins.
+    assert registry.get_config(pkg_name="my_package", target=target) == {
+        "min": "2.0.0",
+        "max": None,
+    }
+
+
+########################################
+#     Tests for min/max/closest/valid  #
+########################################
 
 
 def test_compat_registry_get_min_and_max_versions() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.2.0"}}})
-    assert registry.get_min_and_max_versions(pkg_name="my_package", python_version="3.11") == (
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert registry.get_min_and_max_versions(pkg_name="my_package", target=T311) == (
         Version("1.2.0"),
-        Version("2.2.0"),
-    )
-
-
-def test_compat_registry_get_min_and_max_versions_min_only() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": None}}})
-    assert registry.get_min_and_max_versions(pkg_name="my_package", python_version="3.11") == (
-        Version("1.2.0"),
-        None,
-    )
-
-
-def test_compat_registry_get_min_and_max_versions_max_only() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": None, "max": "2.2.0"}}})
-    assert registry.get_min_and_max_versions(pkg_name="my_package", python_version="3.11") == (
-        None,
         Version("2.2.0"),
     )
 
 
 def test_compat_registry_get_min_and_max_versions_empty() -> None:
     registry = CompatRegistry()
-    assert registry.get_min_and_max_versions(pkg_name="my_package", python_version="3.11") == (
-        None,
-        None,
-    )
+    assert registry.get_min_and_max_versions(pkg_name="my_package", target=T311) == (None, None)
 
 
 def test_compat_registry_find_closest_version_valid() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.2.0"}}})
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
     assert (
-        registry.find_closest_version(
-            pkg_name="my_package", pkg_version="2.0.0", python_version="3.11"
-        )
+        registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
         == "2.0.0"
     )
 
@@ -191,59 +253,50 @@ def test_compat_registry_find_closest_version_valid() -> None:
 def test_compat_registry_find_closest_version_missing() -> None:
     registry = CompatRegistry()
     assert (
-        registry.find_closest_version(
-            pkg_name="my_package", pkg_version="2.0.0", python_version="3.11"
-        )
+        registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
         == "2.0.0"
     )
 
 
 def test_compat_registry_find_closest_version_lower() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.2.0"}}})
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
     assert (
-        registry.find_closest_version(
-            pkg_name="my_package", pkg_version="1.0.0", python_version="3.11"
-        )
+        registry.find_closest_version(pkg_name="my_package", pkg_version="1.0.0", target=T311)
         == "1.2.0"
     )
 
 
 def test_compat_registry_find_closest_version_higher() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.2.0"}}})
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
     assert (
-        registry.find_closest_version(
-            pkg_name="my_package", pkg_version="3.0.0", python_version="3.11"
-        )
+        registry.find_closest_version(pkg_name="my_package", pkg_version="3.0.0", target=T311)
         == "2.2.0"
     )
 
 
 def test_compat_registry_is_valid_version_true() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.2.0"}}})
-    assert registry.is_valid_version(
-        pkg_name="my_package", pkg_version="2.0.0", python_version="3.11"
-    )
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
 
 
 def test_compat_registry_is_valid_version_false_min() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.2.0"}}})
-    assert not registry.is_valid_version(
-        pkg_name="my_package", pkg_version="1.0.0", python_version="3.11"
-    )
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert not registry.is_valid_version(pkg_name="my_package", pkg_version="1.0.0", target=T311)
 
 
 def test_compat_registry_is_valid_version_false_max() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.2.0"}}})
-    assert not registry.is_valid_version(
-        pkg_name="my_package", pkg_version="3.0.0", python_version="3.11"
-    )
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert not registry.is_valid_version(pkg_name="my_package", pkg_version="3.0.0", target=T311)
 
 
 def test_compat_registry_is_valid_version_empty() -> None:
     registry = CompatRegistry()
-    assert registry.is_valid_version(
-        pkg_name="my_package", pkg_version="2.0.0", python_version="3.11"
-    )
+    assert registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T311)
 
 
 ###################################
@@ -252,36 +305,37 @@ def test_compat_registry_is_valid_version_empty() -> None:
 
 
 def test_compat_registry_is_unsupported_true() -> None:
-    registry = CompatRegistry({"my_package": {"3.15": {"min": UNSUPPORTED, "max": UNSUPPORTED}}})
-    assert registry.is_unsupported(pkg_name="my_package", python_version="3.15")
+    registry = CompatRegistry()
+    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    assert registry.is_unsupported(pkg_name="my_package", target=T315)
 
 
 def test_compat_registry_is_unsupported_false() -> None:
-    registry = CompatRegistry({"my_package": {"3.11": {"min": "1.2.0", "max": "2.2.0"}}})
-    assert not registry.is_unsupported(pkg_name="my_package", python_version="3.11")
+    registry = CompatRegistry()
+    registry.register("my_package", T311, "1.2.0", "2.2.0", layer="base")
+    assert not registry.is_unsupported(pkg_name="my_package", target=T311)
 
 
 def test_compat_registry_is_unsupported_unconfigured() -> None:
     registry = CompatRegistry()
-    assert not registry.is_unsupported(pkg_name="my_package", python_version="3.11")
+    assert not registry.is_unsupported(pkg_name="my_package", target=T311)
 
 
 def test_compat_registry_get_min_and_max_versions_unsupported_raises() -> None:
-    registry = CompatRegistry({"my_package": {"3.15": {"min": UNSUPPORTED, "max": UNSUPPORTED}}})
+    registry = CompatRegistry()
+    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
     with pytest.raises(UnsupportedVersionError, match=r"No version of package my_package"):
-        registry.get_min_and_max_versions(pkg_name="my_package", python_version="3.15")
+        registry.get_min_and_max_versions(pkg_name="my_package", target=T315)
 
 
 def test_compat_registry_find_closest_version_unsupported_raises() -> None:
-    registry = CompatRegistry({"my_package": {"3.15": {"min": UNSUPPORTED, "max": UNSUPPORTED}}})
+    registry = CompatRegistry()
+    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
     with pytest.raises(UnsupportedVersionError, match=r"No version of package my_package"):
-        registry.find_closest_version(
-            pkg_name="my_package", pkg_version="2.0.0", python_version="3.15"
-        )
+        registry.find_closest_version(pkg_name="my_package", pkg_version="2.0.0", target=T315)
 
 
 def test_compat_registry_is_valid_version_unsupported_false() -> None:
-    registry = CompatRegistry({"my_package": {"3.15": {"min": UNSUPPORTED, "max": UNSUPPORTED}}})
-    assert not registry.is_valid_version(
-        pkg_name="my_package", pkg_version="2.0.0", python_version="3.15"
-    )
+    registry = CompatRegistry()
+    registry.register("my_package", T315, UNSUPPORTED, UNSUPPORTED, layer="base")
+    assert not registry.is_valid_version(pkg_name="my_package", pkg_version="2.0.0", target=T315)

--- a/tests/unit/compat/test_target.py
+++ b/tests/unit/compat/test_target.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from feu.compat.target import Target
+
+
+def test_target_defaults() -> None:
+    target = Target(python_version="3.11")
+    assert target.python_version == "3.11"
+    assert target.free_threaded is False
+    assert target.os is None
+    assert target.arch is None
+
+
+def test_target_all_fields() -> None:
+    target = Target(python_version="3.14", free_threaded=True, os="macos", arch="arm64")
+    assert target.python_version == "3.14"
+    assert target.free_threaded is True
+    assert target.os == "macos"
+    assert target.arch == "arm64"
+
+
+def test_target_equality() -> None:
+    assert Target(python_version="3.11") == Target(python_version="3.11")
+    assert Target(python_version="3.11") != Target(python_version="3.12")
+    assert Target(python_version="3.11", os="linux") != Target(python_version="3.11")
+
+
+def test_target_is_hashable() -> None:
+    targets = {Target(python_version="3.11"), Target(python_version="3.11")}
+    assert len(targets) == 1
+    targets.add(Target(python_version="3.11", free_threaded=True))
+    assert len(targets) == 2
+
+
+def test_target_used_as_dict_key() -> None:
+    mapping = {Target(python_version="3.11"): "value"}
+    assert mapping[Target(python_version="3.11")] == "value"


### PR DESCRIPTION
## Summary
- Replace the bare `python_version: str` key in `feu.compat` with a `Target(python_version, free_threaded, os, arch)` dataclass, so compatibility rules can distinguish free-threaded builds (e.g. `3.14t`), OS, and architecture in addition to Python version.
- Split `CompatRegistry` into a `base` layer (defaults/discovered data) and an `overrides` layer (user-supplied corrections), with wildcard/specificity matching. Overrides always win and never conflict-check against base, so a discovery refresh can never silently clobber a hand-verified correction.
- Migrate `register_defaults`, the public interface (`register_compat`, `find_closest_version`, `is_valid_version`), the CLI (`feu.__main__`), and the install callsite to the new `Target`-based API.

See the design spec and implementation plan for full details:
- `docs/superpowers/specs/2026-07-31-multiaxis-compat-target-design.md`
- `docs/superpowers/plans/2026-07-31-multiaxis-compat-target.md`

## Test plan
- [x] `pytest tests/unit tests/integration` — 688 passed, 20 skipped
- [x] `pytest --doctest-modules src/feu/compat` — 7 passed
- [x] `ruff check` / `black --check .` clean on touched files
- [x] Docs (`docs/docs/usage.md`, `docs/docs/index.md`) updated to the new `Target`-based API

🤖 Generated with [Claude Code](https://claude.com/claude-code)